### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (Go ${{ matrix.go-version }})


### PR DESCRIPTION
Potential fix for [https://github.com/petabytecl/gaz/security/code-scanning/1](https://github.com/petabytecl/gaz/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml` so all jobs inherit minimal access unless overridden.  
Best single fix here: insert:

```yaml
permissions:
  contents: read
```

right after the `on:` trigger block and before `jobs:`. This preserves current functionality (checkout requires `contents: read`) while eliminating implicit broader token scopes. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
