### PR TITLE
Refactor configured module config providers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,3 +9,9 @@ A lifecycle plan is the application runtime plan derived from the DI container's
 The lifecycle plan is distinct from lifecycle execution. Planning decides what should happen and in what order; execution starts, stops, rolls back, logs, and enforces context deadlines.
 
 The lifecycle plan also owns runtime participant classification for App-managed workers, cron jobs, and framework participants such as the event bus and scheduler. Worker supervision remains the worker manager's implementation concern; the lifecycle plan decides which workers the App runtime hands to that manager.
+
+### Configured module registration
+
+Configured module registration is the shared App-module pattern for wiring a module-owned configuration type into DI. The module owns its public adapter and flags, while the internal configured-module helper owns the repeated mechanics: start from defaults, overlay ProviderValues when available, apply the module's defaulting policy, and validate before exposing the config.
+
+This keeps package-level modules stable as public entry points while centralizing the registration rule that makes flags, config files, environment values, and DI providers agree on one typed config instance.

--- a/config/module/module.go
+++ b/config/module/module.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/internal/configuredmodule"
 )
 
 // Config holds configuration for the config module.
@@ -107,26 +108,10 @@ func New() gaz.Module {
 
 	return gaz.NewModule("config-flags").
 		Flags(defaultCfg.Flags).
-		Provide(func(c *gaz.Container) error {
-			return gaz.For[Config](c).Provider(func(c *gaz.Container) (Config, error) {
-				cfg := defaultCfg
-
-				// Try to load from config manager if available
-				pv, pvErr := gaz.Resolve[*gaz.ProviderValues](c)
-				if pvErr == nil {
-					if unmarshalErr := pv.UnmarshalKey(cfg.Namespace(), &cfg); unmarshalErr != nil {
-						// Ignore error, use defaults (key may not exist)
-						_ = unmarshalErr
-					}
-				}
-
-				cfg.SetDefaults()
-				if validateErr := cfg.Validate(); validateErr != nil {
-					return cfg, fmt.Errorf("validate config module: %w", validateErr)
-				}
-
-				return cfg, nil
-			})
-		}).
+		Provide(configuredmodule.ProvideDefaulted[Config, *Config](
+			&defaultCfg,
+			"config module",
+			"validate config module",
+		)).
 		Build()
 }

--- a/health/module/module.go
+++ b/health/module/module.go
@@ -2,10 +2,9 @@
 package module
 
 import (
-	"fmt"
-
 	"github.com/petabytecl/gaz"
 	"github.com/petabytecl/gaz/health"
+	"github.com/petabytecl/gaz/internal/configuredmodule"
 )
 
 // New creates a health module that provides health.Config with CLI flags.
@@ -30,29 +29,11 @@ func New() gaz.Module {
 
 	return gaz.NewModule("health-flags").
 		Flags(defaultCfg.Flags).
-		Provide(func(c *gaz.Container) error {
-			// Register Config provider
-			return gaz.For[health.Config](c).Provider(func(c *gaz.Container) (health.Config, error) {
-				// Start with the default configuration which has flags bound to it
-				cfg := defaultCfg
-
-				// Try to load from config manager if available
-				pv, pvErr := gaz.Resolve[*gaz.ProviderValues](c)
-				if pvErr == nil {
-					if unmarshalErr := pv.UnmarshalKey(cfg.Namespace(), &cfg); unmarshalErr != nil {
-						// Ignore error, use defaults (key may not exist)
-						_ = unmarshalErr
-					}
-				}
-
-				cfg.SetDefaults()
-				if validateErr := cfg.Validate(); validateErr != nil {
-					return cfg, fmt.Errorf("validate health config: %w", validateErr)
-				}
-
-				return cfg, nil
-			})
-		}).
+		Provide(configuredmodule.ProvideDefaulted[health.Config, *health.Config](
+			&defaultCfg,
+			"health config",
+			"validate health config",
+		)).
 		Provide(health.Module).
 		Build()
 }

--- a/internal/configuredmodule/config.go
+++ b/internal/configuredmodule/config.go
@@ -48,6 +48,10 @@ func provide[T any, PT namespacedValidatedConfig[T]](
 	beforeValidate func(PT),
 ) func(*gaz.Container) error {
 	return func(c *gaz.Container) error {
+		if defaults == nil {
+			return fmt.Errorf("register %s: defaults must not be nil", registrationName)
+		}
+
 		if err := gaz.For[T](c).Provider(func(c *gaz.Container) (T, error) {
 			cfg := *defaults
 			cfgPtr := PT(&cfg)

--- a/internal/configuredmodule/config.go
+++ b/internal/configuredmodule/config.go
@@ -1,0 +1,72 @@
+// Package configuredmodule centralizes repeated module config provider wiring.
+package configuredmodule
+
+import (
+	"fmt"
+
+	"github.com/petabytecl/gaz"
+)
+
+type namespacedValidatedConfig[T any] interface {
+	*T
+	Namespace() string
+	Validate() error
+}
+
+type defaultedConfig[T any] interface {
+	namespacedValidatedConfig[T]
+	SetDefaults()
+}
+
+// ProvideValidated registers a config provider that starts from defaults,
+// optionally overlays ProviderValues, and validates the resulting config.
+func ProvideValidated[T any, PT namespacedValidatedConfig[T]](
+	defaults *T,
+	registrationName string,
+	validationContext string,
+) func(*gaz.Container) error {
+	return provide(defaults, registrationName, validationContext, func(PT) {})
+}
+
+// ProvideDefaulted registers a config provider that starts from defaults,
+// optionally overlays ProviderValues, reapplies zero-value defaults, and
+// validates the resulting config.
+func ProvideDefaulted[T any, PT defaultedConfig[T]](
+	defaults *T,
+	registrationName string,
+	validationContext string,
+) func(*gaz.Container) error {
+	return provide(defaults, registrationName, validationContext, func(cfg PT) {
+		cfg.SetDefaults()
+	})
+}
+
+func provide[T any, PT namespacedValidatedConfig[T]](
+	defaults *T,
+	registrationName string,
+	validationContext string,
+	beforeValidate func(PT),
+) func(*gaz.Container) error {
+	return func(c *gaz.Container) error {
+		if err := gaz.For[T](c).Provider(func(c *gaz.Container) (T, error) {
+			cfg := *defaults
+			cfgPtr := PT(&cfg)
+
+			if pv, err := gaz.Resolve[*gaz.ProviderValues](c); err == nil {
+				if unmarshalErr := pv.UnmarshalKey(cfgPtr.Namespace(), &cfg); unmarshalErr != nil {
+					_ = unmarshalErr
+				}
+			}
+
+			beforeValidate(cfgPtr)
+			if err := cfgPtr.Validate(); err != nil {
+				return cfg, fmt.Errorf("%s: %w", validationContext, err)
+			}
+
+			return cfg, nil
+		}); err != nil {
+			return fmt.Errorf("register %s: %w", registrationName, err)
+		}
+		return nil
+	}
+}

--- a/internal/configuredmodule/config_test.go
+++ b/internal/configuredmodule/config_test.go
@@ -140,3 +140,44 @@ func TestProviderUsesLatestDefaultValues(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mutatedEndpoint, cfg.Endpoint)
 }
+
+func TestProvidersRejectNilDefaults(t *testing.T) {
+	tests := []struct {
+		name    string
+		provide func() func(*gaz.Container) error
+	}{
+		{
+			name: "validated",
+			provide: func() func(*gaz.Container) error {
+				return ProvideValidated[sampleValidatedConfig, *sampleValidatedConfig](
+					nil,
+					"validated config",
+					"validated config validate",
+				)
+			},
+		},
+		{
+			name: "defaulted",
+			provide: func() func(*gaz.Container) error {
+				return ProvideDefaulted[sampleDefaultedConfig, *sampleDefaultedConfig](
+					nil,
+					"defaulted config",
+					"validate defaulted config",
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := gaz.New()
+			app.Use(gaz.NewModule(tt.name).
+				Provide(tt.provide()).
+				Build())
+
+			err := app.Build()
+			require.Error(t, err)
+			require.ErrorContains(t, err, "defaults must not be nil")
+		})
+	}
+}

--- a/internal/configuredmodule/config_test.go
+++ b/internal/configuredmodule/config_test.go
@@ -1,0 +1,142 @@
+package configuredmodule
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/petabytecl/gaz"
+)
+
+const (
+	defaultName     = "from-default"
+	loadedName      = "from-provider-values"
+	mutatedEndpoint = "https://mutated.example.test"
+	requiredName    = "configured"
+)
+
+type sampleDefaultedConfig struct {
+	Name      string `mapstructure:"name"`
+	Required  string `mapstructure:"required"`
+	Defaulted string `mapstructure:"defaulted"`
+}
+
+func (c *sampleDefaultedConfig) Namespace() string {
+	return "sample"
+}
+
+func (c *sampleDefaultedConfig) SetDefaults() {
+	if c.Defaulted == "" {
+		c.Defaulted = defaultName
+	}
+}
+
+func (c *sampleDefaultedConfig) Validate() error {
+	if c.Required == "" {
+		return errors.New("required is missing")
+	}
+	return nil
+}
+
+type sampleValidatedConfig struct {
+	Endpoint string `mapstructure:"endpoint"`
+}
+
+func (c *sampleValidatedConfig) Namespace() string {
+	return "validated"
+}
+
+func (c *sampleValidatedConfig) Validate() error {
+	if c.Endpoint == "" {
+		return errors.New("endpoint is missing")
+	}
+	return nil
+}
+
+func TestProvideDefaultedLoadsProviderValuesAndAppliesDefaults(t *testing.T) {
+	app := gaz.New()
+	require.NoError(t, app.MergeConfigMap(map[string]any{
+		"sample": map[string]any{
+			"name":     loadedName,
+			"required": requiredName,
+		},
+	}))
+	defaults := sampleDefaultedConfig{Name: defaultName}
+	app.Use(gaz.NewModule("sample").
+		Provide(ProvideDefaulted[sampleDefaultedConfig, *sampleDefaultedConfig](
+			&defaults,
+			"sample config",
+			"validate sample config",
+		)).
+		Build())
+
+	require.NoError(t, app.Build())
+
+	cfg, err := gaz.Resolve[sampleDefaultedConfig](app.Container())
+	require.NoError(t, err)
+	require.Equal(t, loadedName, cfg.Name)
+	require.Equal(t, requiredName, cfg.Required)
+	require.Equal(t, defaultName, cfg.Defaulted)
+}
+
+func TestProvideDefaultedWrapsValidationContext(t *testing.T) {
+	app := gaz.New()
+	defaults := sampleDefaultedConfig{}
+	app.Use(gaz.NewModule("sample").
+		Provide(ProvideDefaulted[sampleDefaultedConfig, *sampleDefaultedConfig](
+			&defaults,
+			"sample config",
+			"validate sample config",
+		)).
+		Build())
+
+	require.NoError(t, app.Build())
+
+	_, err := gaz.Resolve[sampleDefaultedConfig](app.Container())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "validate sample config")
+}
+
+func TestProvideValidatedLoadsProviderValues(t *testing.T) {
+	app := gaz.New()
+	require.NoError(t, app.MergeConfigMap(map[string]any{
+		"validated": map[string]any{
+			"endpoint": "https://example.test",
+		},
+	}))
+	defaults := sampleValidatedConfig{}
+	app.Use(gaz.NewModule("validated").
+		Provide(ProvideValidated[sampleValidatedConfig, *sampleValidatedConfig](
+			&defaults,
+			"validated config",
+			"validated config validate",
+		)).
+		Build())
+
+	require.NoError(t, app.Build())
+
+	cfg, err := gaz.Resolve[sampleValidatedConfig](app.Container())
+	require.NoError(t, err)
+	require.Equal(t, "https://example.test", cfg.Endpoint)
+}
+
+func TestProviderUsesLatestDefaultValues(t *testing.T) {
+	app := gaz.New()
+	defaults := sampleValidatedConfig{Endpoint: "https://initial.example.test"}
+	app.Use(gaz.NewModule("validated").
+		Provide(ProvideValidated[sampleValidatedConfig, *sampleValidatedConfig](
+			&defaults,
+			"validated config",
+			"validated config validate",
+		)).
+		Build())
+
+	defaults.Endpoint = mutatedEndpoint
+
+	require.NoError(t, app.Build())
+
+	cfg, err := gaz.Resolve[sampleValidatedConfig](app.Container())
+	require.NoError(t, err)
+	require.Equal(t, mutatedEndpoint, cfg.Endpoint)
+}

--- a/logger/module/module.go
+++ b/logger/module/module.go
@@ -2,9 +2,8 @@
 package module
 
 import (
-	"fmt"
-
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/internal/configuredmodule"
 	"github.com/petabytecl/gaz/logger"
 )
 
@@ -29,26 +28,10 @@ func New() gaz.Module {
 
 	return gaz.NewModule("logger").
 		Flags(defaultCfg.Flags).
-		Provide(func(c *gaz.Container) error {
-			return gaz.For[logger.Config](c).Provider(func(c *gaz.Container) (logger.Config, error) {
-				cfg := defaultCfg
-
-				// Try to load from config manager if available
-				pv, pvErr := gaz.Resolve[*gaz.ProviderValues](c)
-				if pvErr == nil {
-					if unmarshalErr := pv.UnmarshalKey(cfg.Namespace(), &cfg); unmarshalErr != nil {
-						// Ignore error, use defaults (key may not exist)
-						_ = unmarshalErr
-					}
-				}
-
-				cfg.SetDefaults()
-				if validateErr := cfg.Validate(); validateErr != nil {
-					return cfg, fmt.Errorf("validate logger config: %w", validateErr)
-				}
-
-				return cfg, nil
-			})
-		}).
+		Provide(configuredmodule.ProvideDefaulted[logger.Config, *logger.Config](
+			&defaultCfg,
+			"logger config",
+			"validate logger config",
+		)).
 		Build()
 }

--- a/server/grpc/module.go
+++ b/server/grpc/module.go
@@ -7,6 +7,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/internal/configuredmodule"
 )
 
 // resolveLogger attempts to resolve a logger from the container, falling back to slog.Default().
@@ -18,24 +19,12 @@ func resolveLogger(c *gaz.Container) *slog.Logger {
 }
 
 // provideConfig creates a Config provider function.
-func provideConfig(defaultCfg Config) func(*gaz.Container) error {
-	return func(c *gaz.Container) error {
-		return gaz.For[Config](c).Provider(func(c *gaz.Container) (Config, error) {
-			cfg := defaultCfg
-
-			if pv, err := gaz.Resolve[*gaz.ProviderValues](c); err == nil {
-				if unmarshalErr := pv.UnmarshalKey(defaultCfg.Namespace(), &cfg); unmarshalErr != nil {
-					_ = unmarshalErr
-				}
-			}
-
-			if err := cfg.Validate(); err != nil {
-				return Config{}, fmt.Errorf("grpc config validate: %w", err)
-			}
-
-			return cfg, nil
-		})
-	}
+func provideConfig(defaultCfg *Config) func(*gaz.Container) error {
+	return configuredmodule.ProvideValidated[Config, *Config](
+		defaultCfg,
+		"grpc config",
+		"grpc config validate",
+	)
 }
 
 // provideLoggingBundle creates a LoggingBundle provider function.
@@ -177,7 +166,7 @@ func NewModule() gaz.Module {
 
 	return gaz.NewModule("grpc").
 		Flags(defaultCfg.Flags).
-		Provide(provideConfig(defaultCfg)).
+		Provide(provideConfig(&defaultCfg)).
 		Provide(provideLoggingBundle).
 		Provide(provideRateLimitBundle).
 		Provide(provideAuthBundle).

--- a/server/http/module.go
+++ b/server/http/module.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/internal/configuredmodule"
 )
 
 // NewModule creates an HTTP module.
@@ -27,27 +28,11 @@ func NewModule() gaz.Module {
 
 	return gaz.NewModule("http").
 		Flags(defaultCfg.Flags).
-		Provide(func(c *gaz.Container) error {
-			// Register Config provider
-			return gaz.For[Config](c).Provider(func(c *gaz.Container) (Config, error) {
-				// Start with the default configuration which has flags bound to it
-				cfg := defaultCfg
-
-				// Resolve ProviderValues to load config
-				if pv, err := gaz.Resolve[*gaz.ProviderValues](c); err == nil {
-					if unmarshalErr := pv.UnmarshalKey(defaultCfg.Namespace(), &cfg); unmarshalErr != nil {
-						// ignore error, use defaults
-						_ = unmarshalErr
-					}
-				}
-
-				if err := cfg.Validate(); err != nil {
-					return Config{}, fmt.Errorf("http config validate: %w", err)
-				}
-
-				return cfg, nil
-			})
-		}).
+		Provide(configuredmodule.ProvideValidated[Config, *Config](
+			&defaultCfg,
+			"http config",
+			"http config validate",
+		)).
 		Provide(func(c *gaz.Container) error {
 			// Register Server
 			return gaz.For[*Server](c).

--- a/server/vanguard/module.go
+++ b/server/vanguard/module.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/petabytecl/gaz"
 	"github.com/petabytecl/gaz/health"
+	"github.com/petabytecl/gaz/internal/configuredmodule"
 	connectpkg "github.com/petabytecl/gaz/server/connect"
 	grpcpkg "github.com/petabytecl/gaz/server/grpc"
 )
@@ -21,24 +22,12 @@ func resolveLogger(c *gaz.Container) *slog.Logger {
 }
 
 // provideConfig creates a Config provider function.
-func provideConfig(defaultCfg Config) func(*gaz.Container) error {
-	return func(c *gaz.Container) error {
-		return gaz.For[Config](c).Provider(func(c *gaz.Container) (Config, error) {
-			cfg := defaultCfg
-
-			if pv, err := gaz.Resolve[*gaz.ProviderValues](c); err == nil {
-				if unmarshalErr := pv.UnmarshalKey(defaultCfg.Namespace(), &cfg); unmarshalErr != nil {
-					_ = unmarshalErr
-				}
-			}
-
-			if err := cfg.Validate(); err != nil {
-				return Config{}, fmt.Errorf("vanguard config validate: %w", err)
-			}
-
-			return cfg, nil
-		})
-	}
+func provideConfig(defaultCfg *Config) func(*gaz.Container) error {
+	return configuredmodule.ProvideValidated[Config, *Config](
+		defaultCfg,
+		"vanguard config",
+		"vanguard config validate",
+	)
 }
 
 // provideCORSMiddleware registers a CORSMiddleware in the DI container.
@@ -236,7 +225,7 @@ func NewModule() gaz.Module {
 
 	return gaz.NewModule("vanguard").
 		Flags(defaultCfg.Flags).
-		Provide(provideConfig(defaultCfg)).
+		Provide(provideConfig(&defaultCfg)).
 		Provide(provideCORSMiddleware).
 		Provide(provideOTELMiddleware).
 		Provide(provideOTELConnectBundle).

--- a/server/vanguard/module_test.go
+++ b/server/vanguard/module_test.go
@@ -70,7 +70,7 @@ func (s *ModuleTestSuite) TestProvideConfig_RegistersConfig() {
 	cfg := DefaultConfig()
 	cfg.AllowZeroWriteTimeout = true // Explicit opt-in for streaming-safe zero timeout.
 
-	err := provideConfig(cfg)(container)
+	err := provideConfig(&cfg)(container)
 	s.Require().NoError(err)
 
 	// Resolve the config provider — it should produce a valid Config.
@@ -83,7 +83,7 @@ func (s *ModuleTestSuite) TestProvideConfig_InvalidConfig() {
 	container := di.New()
 	cfg := Config{Port: 0} // Invalid — port must be > 0.
 
-	err := provideConfig(cfg)(container)
+	err := provideConfig(&cfg)(container)
 	s.Require().NoError(err, "registration should succeed")
 
 	// Resolution should fail due to validation.
@@ -277,7 +277,7 @@ func (s *ModuleTestSuite) TestProvideConfig_WithProviderValues() {
 	// Register ProviderValues to trigger the unmarshal path.
 	// Since we don't have a real ProviderValues, we just verify the config
 	// resolves correctly without one.
-	err := provideConfig(cfg)(container)
+	err := provideConfig(&cfg)(container)
 	s.Require().NoError(err)
 
 	resolved, resolveErr := di.Resolve[Config](container)
@@ -289,7 +289,7 @@ func (s *ModuleTestSuite) TestProvideConfig_ResolveTwiceReturnsCachedSingleton()
 	container := di.New()
 	cfg := DefaultConfig()
 
-	err := provideConfig(cfg)(container)
+	err := provideConfig(&cfg)(container)
 	s.Require().NoError(err)
 
 	r1, err1 := di.Resolve[Config](container)


### PR DESCRIPTION
## Summary
- Add an internal configuredmodule helper for repeated module config provider wiring.
- Migrate logger, health, config, HTTP, gRPC, and Vanguard module config registration to the shared helper.
- Document configured module registration in CONTEXT.md and add regression coverage for provider-value loading, validation wrapping, and flag-mutated defaults.

## Verification
- go test ./internal/configuredmodule ./logger/module ./health/module ./config/module ./server/http ./server/grpc ./server/vanguard
- make check
- make lint
- make cover
- tmp goimports PATH fallback + make fmt-check
