### PR TITLE
Refactor lifecycle runtime planning

### DIFF
--- a/app.go
+++ b/app.go
@@ -127,8 +127,8 @@ type App struct {
 	// EventBus for pub/sub - nil until Build() is called
 	eventBus *eventbus.EventBus
 
-	// cachedLifecyclePlan stores the plan computed during startServices,
-	// reused by doStop to avoid re-walking the container during shutdown.
+	// cachedLifecyclePlan stores the runtime plan computed during Build,
+	// reused by start and stop so App execution does not re-walk the container.
 	cachedLifecyclePlan *lifecyclePlan
 
 	mu      sync.Mutex

--- a/app.go
+++ b/app.go
@@ -127,8 +127,8 @@ type App struct {
 	// EventBus for pub/sub - nil until Build() is called
 	eventBus *eventbus.EventBus
 
-	// cachedLifecyclePlan stores the runtime plan computed during Build,
-	// reused by start and stop so App execution does not re-walk the container.
+	// cachedLifecyclePlan stores the structural runtime plan computed during Build.
+	// Start resolves lifecycle services into it before execution; Stop reuses it.
 	cachedLifecyclePlan *lifecyclePlan
 
 	mu      sync.Mutex

--- a/app_build.go
+++ b/app_build.go
@@ -198,8 +198,18 @@ func (a *App) Build() error {
 	}
 
 	if len(errs) == 0 {
-		plan := newRuntimeParticipantPlan(a.container)
+		plan, planErr := newLifecyclePlan(a.container)
+		if planErr != nil {
+			errs = append(errs, planErr)
+		} else {
+			a.cachedLifecyclePlan = plan
+		}
+	}
+
+	if len(errs) == 0 {
+		plan := a.cachedLifecyclePlan
 		errs = append(errs, plan.registerRuntimeParticipants(
+			a.container,
 			a.workerMgr,
 			a.eventBus,
 			a.scheduler,

--- a/app_run.go
+++ b/app_run.go
@@ -49,6 +49,10 @@ func (a *App) startServices(ctx context.Context) error {
 		return err
 	}
 
+	if err = plan.resolveLifecycleServices(a.container); err != nil {
+		return err
+	}
+
 	a.Logger.InfoContext(ctx, "starting application", "services_count", len(plan.services))
 
 	// Start services layer by layer

--- a/app_run.go
+++ b/app_run.go
@@ -44,19 +44,9 @@ func (a *App) Run(ctx context.Context) error {
 // layer by layer in parallel, and then starts the worker manager. On failure at any
 // stage it rolls back by stopping already-started services.
 func (a *App) startServices(ctx context.Context) error {
-	a.mu.Lock()
-	plan := a.cachedLifecyclePlan
-	a.mu.Unlock()
-	if plan == nil {
-		var err error
-		plan, err = newLifecyclePlan(a.container)
-		if err != nil {
-			return err
-		}
-
-		a.mu.Lock()
-		a.cachedLifecyclePlan = plan
-		a.mu.Unlock()
+	plan, err := a.lifecyclePlan()
+	if err != nil {
+		return err
 	}
 
 	a.Logger.InfoContext(ctx, "starting application", "services_count", len(plan.services))

--- a/app_shutdown.go
+++ b/app_shutdown.go
@@ -63,19 +63,11 @@ func (a *App) doStop(ctx context.Context) error {
 		}
 	}()
 
-	// Use cached lifecycle plan from startServices if available,
-	// fallback to planning now if Stop is called without Run/Start.
-	a.mu.Lock()
-	plan := a.cachedLifecyclePlan
-	a.mu.Unlock()
-	if plan == nil {
-		var err error
-		plan, err = newLifecyclePlan(a.container)
-		if err != nil {
-			close(done)
-			// Should not happen if Build passed, unless graph changed (impossible after Build)
-			return err
-		}
+	plan, err := a.lifecyclePlan()
+	if err != nil {
+		close(done)
+		// Should not happen if Build passed, unless graph changed (impossible after Build)
+		return err
 	}
 
 	var errs []error

--- a/lifecycle_plan.go
+++ b/lifecycle_plan.go
@@ -3,7 +3,6 @@ package gaz
 import (
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/petabytecl/gaz/cron"
 	"github.com/petabytecl/gaz/di"
@@ -16,19 +15,45 @@ type lifecyclePlan struct {
 	services           map[string]di.ServiceWrapper
 	startupOrder       [][]string
 	shutdownOrder      [][]string
-	workerParticipants []worker.Worker
+	workerParticipants []lifecycleWorkerParticipant
 	cronJobs           []lifecycleCronJob
+}
+
+type lifecycleWorkerParticipant struct {
+	serviceName string
 }
 
 type lifecycleCronJob struct {
 	serviceName string
-	jobName     string
-	schedule    string
-	timeout     time.Duration
 	transient   bool
 }
 
 const runtimeParticipantErrorCapacity = 2
+
+func (a *App) lifecyclePlan() (*lifecyclePlan, error) {
+	a.mu.Lock()
+	plan := a.cachedLifecyclePlan
+	a.mu.Unlock()
+	if plan != nil {
+		return plan, nil
+	}
+
+	planned, err := newLifecyclePlan(a.container)
+	if err != nil {
+		return nil, err
+	}
+
+	a.mu.Lock()
+	if a.cachedLifecyclePlan == nil {
+		a.cachedLifecyclePlan = planned
+		plan = planned
+	} else {
+		plan = a.cachedLifecyclePlan
+	}
+	a.mu.Unlock()
+
+	return plan, nil
+}
 
 func newLifecyclePlan(container *Container) (*lifecyclePlan, error) {
 	services, err := collectLifecyclePlanServices(container, true)
@@ -41,19 +66,15 @@ func newLifecyclePlan(container *Container) (*lifecyclePlan, error) {
 		return nil, err
 	}
 
-	return &lifecyclePlan{
-		services:      services,
-		startupOrder:  startupOrder,
-		shutdownOrder: ComputeShutdownOrder(startupOrder),
-	}, nil
-}
-
-func newRuntimeParticipantPlan(container *Container) *lifecyclePlan {
 	workerParticipants, cronJobs := collectRuntimeParticipants(container)
+
 	return &lifecyclePlan{
+		services:           services,
+		startupOrder:       startupOrder,
+		shutdownOrder:      ComputeShutdownOrder(startupOrder),
 		workerParticipants: workerParticipants,
 		cronJobs:           cronJobs,
-	}
+	}, nil
 }
 
 func collectLifecyclePlanServices(
@@ -87,8 +108,8 @@ func collectLifecyclePlanServices(
 	return services, resolveErr
 }
 
-func collectRuntimeParticipants(container *Container) ([]worker.Worker, []lifecycleCronJob) {
-	var workerParticipants []worker.Worker
+func collectRuntimeParticipants(container *Container) ([]lifecycleWorkerParticipant, []lifecycleCronJob) {
+	var workerParticipants []lifecycleWorkerParticipant
 	var cronJobs []lifecycleCronJob
 
 	container.ForEachService(func(name string, svc di.ServiceWrapper) {
@@ -96,11 +117,13 @@ func collectRuntimeParticipants(container *Container) ([]worker.Worker, []lifecy
 			if isFrameworkEventBus(svc) {
 				return
 			}
-			workerParticipants = appendWorkerParticipant(container, name, workerParticipants)
+			workerParticipants = append(workerParticipants, lifecycleWorkerParticipant{
+				serviceName: name,
+			})
 			return
 		}
 
-		cronJobs = appendCronJobParticipant(container, name, svc, cronJobs)
+		cronJobs = appendCronJobParticipant(name, svc, cronJobs)
 	})
 
 	return workerParticipants, cronJobs
@@ -125,23 +148,7 @@ func isCronJobParticipant(svc di.ServiceWrapper) bool {
 	return st != nil && st.Implements(cronJobType)
 }
 
-func appendWorkerParticipant(
-	container *Container,
-	name string,
-	participants []worker.Worker,
-) []worker.Worker {
-	instance, err := container.ResolveByName(name, nil)
-	if err != nil {
-		return participants
-	}
-	if w, ok := instance.(worker.Worker); ok {
-		return append(participants, w)
-	}
-	return participants
-}
-
 func appendCronJobParticipant(
-	container *Container,
 	name string,
 	svc di.ServiceWrapper,
 	jobs []lifecycleCronJob,
@@ -150,26 +157,14 @@ func appendCronJobParticipant(
 		return jobs
 	}
 
-	instance, err := container.ResolveByName(name, nil)
-	if err != nil {
-		return jobs
-	}
-
-	job, ok := instance.(cron.CronJob)
-	if !ok {
-		return jobs
-	}
-
 	return append(jobs, lifecycleCronJob{
 		serviceName: name,
-		jobName:     job.Name(),
-		schedule:    job.Schedule(),
-		timeout:     job.Timeout(),
 		transient:   svc.IsTransient(),
 	})
 }
 
 func (p *lifecyclePlan) registerRuntimeParticipants(
+	container *Container,
 	workerMgr *worker.Manager,
 	eventBus worker.Worker,
 	scheduler *cron.Scheduler,
@@ -180,19 +175,33 @@ func (p *lifecyclePlan) registerRuntimeParticipants(
 	}
 
 	errs := make([]error, 0, runtimeParticipantErrorCapacity)
-	p.registerWorkers(workerMgr, log)
+	p.registerWorkers(container, workerMgr, log)
 	errs = append(errs, p.registerEventBus(workerMgr, eventBus)...)
-	p.registerCronJobs(scheduler, log)
+	p.registerCronJobs(container, scheduler, log)
 	errs = append(errs, p.registerScheduler(workerMgr, scheduler)...)
 	return errs
 }
 
-func (p *lifecyclePlan) registerWorkers(workerMgr *worker.Manager, log *slog.Logger) {
+func (p *lifecyclePlan) registerWorkers(
+	container *Container,
+	workerMgr *worker.Manager,
+	log *slog.Logger,
+) {
 	if workerMgr == nil {
 		return
 	}
 
-	for _, w := range p.workerParticipants {
+	for _, participant := range p.workerParticipants {
+		instance, err := container.ResolveByName(participant.serviceName, nil)
+		if err != nil {
+			continue
+		}
+
+		w, ok := instance.(worker.Worker)
+		if !ok {
+			continue
+		}
+
 		if regErr := workerMgr.Register(w); regErr != nil {
 			log.Warn("failed to register worker",
 				"name", w.Name(),
@@ -216,26 +225,40 @@ func (p *lifecyclePlan) registerEventBus(
 	return nil
 }
 
-func (p *lifecyclePlan) registerCronJobs(scheduler *cron.Scheduler, log *slog.Logger) {
+func (p *lifecyclePlan) registerCronJobs(
+	container *Container,
+	scheduler *cron.Scheduler,
+	log *slog.Logger,
+) {
 	if scheduler == nil {
 		return
 	}
 
-	for _, job := range p.cronJobs {
-		if !job.transient {
+	for _, participant := range p.cronJobs {
+		instance, err := container.ResolveByName(participant.serviceName, nil)
+		if err != nil {
+			continue
+		}
+
+		job, ok := instance.(cron.CronJob)
+		if !ok {
+			continue
+		}
+
+		if !participant.transient {
 			log.Warn("CronJob should be transient",
-				"name", job.serviceName,
+				"name", participant.serviceName,
 			)
 		}
 
 		if regErr := scheduler.RegisterJob(
-			job.serviceName,
-			job.jobName,
-			job.schedule,
-			job.timeout,
+			participant.serviceName,
+			job.Name(),
+			job.Schedule(),
+			job.Timeout(),
 		); regErr != nil {
 			log.Warn("failed to register cron job",
-				"name", job.jobName,
+				"name", job.Name(),
 				"error", regErr,
 			)
 		}

--- a/lifecycle_plan.go
+++ b/lifecycle_plan.go
@@ -3,13 +3,14 @@ package gaz
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/petabytecl/gaz/cron"
 	"github.com/petabytecl/gaz/di"
 	"github.com/petabytecl/gaz/worker"
 )
 
-// lifecyclePlan is the pure runtime plan derived from the DI container graph.
+// lifecyclePlan is the structural runtime plan derived from the DI container graph.
 // It owns lifecycle policy; App owns execution, logging, rollback, and deadlines.
 type lifecyclePlan struct {
 	services           map[string]di.ServiceWrapper
@@ -56,10 +57,7 @@ func (a *App) lifecyclePlan() (*lifecyclePlan, error) {
 }
 
 func newLifecyclePlan(container *Container) (*lifecyclePlan, error) {
-	services, err := collectLifecyclePlanServices(container, true)
-	if err != nil {
-		return nil, err
-	}
+	services := collectLifecyclePlanServices(container)
 
 	startupOrder, err := ComputeStartupOrder(container.GetGraph(), services)
 	if err != nil {
@@ -77,17 +75,10 @@ func newLifecyclePlan(container *Container) (*lifecyclePlan, error) {
 	}, nil
 }
 
-func collectLifecyclePlanServices(
-	container *Container,
-	resolveLifecycle bool,
-) (map[string]di.ServiceWrapper, error) {
+func collectLifecyclePlanServices(container *Container) map[string]di.ServiceWrapper {
 	services := make(map[string]di.ServiceWrapper)
-	var resolveErr error
 
 	container.ForEachService(func(name string, svc di.ServiceWrapper) {
-		if resolveErr != nil {
-			return
-		}
 		if svc.IsTransient() {
 			return
 		}
@@ -96,16 +87,39 @@ func collectLifecyclePlanServices(
 			return
 		}
 
-		if resolveLifecycle && svc.HasLifecycle() {
-			if _, err := container.ResolveByName(name, nil); err != nil {
-				resolveErr = fmt.Errorf("lifecycle plan resolving %s: %w", name, err)
-				return
-			}
-		}
 		services[name] = svc
 	})
 
-	return services, resolveErr
+	return services
+}
+
+func (p *lifecyclePlan) resolveLifecycleServices(container *Container) error {
+	names := p.lifecycleServiceNames()
+	for _, name := range names {
+		if _, err := container.ResolveByName(name, nil); err != nil {
+			return fmt.Errorf("lifecycle plan resolving %s: %w", name, err)
+		}
+	}
+
+	startupOrder, err := ComputeStartupOrder(container.GetGraph(), p.services)
+	if err != nil {
+		return err
+	}
+
+	p.startupOrder = startupOrder
+	p.shutdownOrder = ComputeShutdownOrder(startupOrder)
+	return nil
+}
+
+func (p *lifecyclePlan) lifecycleServiceNames() []string {
+	names := make([]string, 0, len(p.services))
+	for name, svc := range p.services {
+		if svc.HasLifecycle() {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
 }
 
 func collectRuntimeParticipants(container *Container) ([]lifecycleWorkerParticipant, []lifecycleCronJob) {

--- a/lifecycle_plan_test.go
+++ b/lifecycle_plan_test.go
@@ -2,6 +2,7 @@ package gaz
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -50,6 +51,33 @@ type lifecyclePlanLazyPlain struct{}
 
 type lifecyclePlanRuntimeHelper struct{}
 
+type lifecyclePlanCountedService struct {
+	onStart func()
+}
+
+func (s *lifecyclePlanCountedService) OnStart(context.Context) error {
+	if s.onStart != nil {
+		s.onStart()
+	}
+	return nil
+}
+
+func (s *lifecyclePlanCountedService) OnStop(context.Context) error { return nil }
+
+type lifecyclePlanCountedDependent struct {
+	dependency *lifecyclePlanCountedService
+	onStart    func()
+}
+
+func (s *lifecyclePlanCountedDependent) OnStart(context.Context) error {
+	if s.onStart != nil {
+		s.onStart()
+	}
+	return nil
+}
+
+func (s *lifecyclePlanCountedDependent) OnStop(context.Context) error { return nil }
+
 func TestLifecyclePlanOwnsSelectionAndOrderPolicy(t *testing.T) {
 	c := NewContainer()
 
@@ -96,6 +124,8 @@ func TestLifecyclePlanOwnsSelectionAndOrderPolicy(t *testing.T) {
 	assert.NotContains(t, plan.services, "transient")
 	assert.NotContains(t, plan.services, "worker")
 	assert.NotContains(t, plan.services, "cron-job")
+
+	require.NoError(t, plan.resolveLifecycleServices(c))
 
 	assert.Equal(t, [][]string{{"dependency"}, {"dependent"}}, plan.startupOrder)
 	assert.Equal(t, [][]string{{"dependent"}, {"dependency"}}, plan.shutdownOrder)
@@ -206,6 +236,63 @@ func TestAppBuildCachesFullLifecyclePlan(t *testing.T) {
 
 	require.Len(t, plan.cronJobs, 1)
 	assert.Equal(t, "cron-job", plan.cronJobs[0].serviceName)
+}
+
+func TestAppBuildDoesNotResolveLifecycleServices(t *testing.T) {
+	app := New()
+	var dependencyResolutions atomic.Int32
+	var dependentResolutions atomic.Int32
+	var startMu sync.Mutex
+	var starts []string
+
+	recordStart := func(name string) func() {
+		return func() {
+			startMu.Lock()
+			defer startMu.Unlock()
+			starts = append(starts, name)
+		}
+	}
+
+	require.NoError(t, For[*lifecyclePlanCountedService](app.Container()).Named("z-dependency").
+		ProviderFunc(func(*Container) *lifecyclePlanCountedService {
+			dependencyResolutions.Add(1)
+			return &lifecyclePlanCountedService{
+				onStart: recordStart("z-dependency"),
+			}
+		}))
+
+	require.NoError(t, For[*lifecyclePlanCountedDependent](app.Container()).Named("a-dependent").
+		Provider(func(c *Container) (*lifecyclePlanCountedDependent, error) {
+			dependentResolutions.Add(1)
+			dep, err := Resolve[*lifecyclePlanCountedService](c, Named("z-dependency"))
+			if err != nil {
+				return nil, err
+			}
+			return &lifecyclePlanCountedDependent{
+				dependency: dep,
+				onStart:    recordStart("a-dependent"),
+			}, nil
+		}))
+
+	require.NoError(t, app.Build())
+	assert.Zero(t, dependencyResolutions.Load())
+	assert.Zero(t, dependentResolutions.Load())
+
+	plan := app.cachedLifecyclePlan
+	require.NotNil(t, plan)
+	assert.Contains(t, plan.services, "z-dependency")
+	assert.Contains(t, plan.services, "a-dependent")
+
+	require.NoError(t, app.Start(context.Background()))
+	assert.Equal(t, int32(1), dependencyResolutions.Load())
+	assert.Equal(t, int32(1), dependentResolutions.Load())
+
+	startMu.Lock()
+	started := append([]string(nil), starts...)
+	startMu.Unlock()
+	assert.Equal(t, []string{"z-dependency", "a-dependent"}, started)
+
+	require.NoError(t, app.Stop(context.Background()))
 }
 
 func flattenLifecycleOrder(order [][]string) []string {

--- a/lifecycle_plan_test.go
+++ b/lifecycle_plan_test.go
@@ -106,14 +106,12 @@ func TestLifecyclePlanOwnsSelectionAndOrderPolicy(t *testing.T) {
 	assert.NotContains(t, flattened, "worker")
 	assert.NotContains(t, flattened, "cron-job")
 
-	runtimePlan := newRuntimeParticipantPlan(c)
-	require.Len(t, runtimePlan.workerParticipants, 1)
-	assert.Equal(t, "worker", runtimePlan.workerParticipants[0].Name())
+	require.Len(t, plan.workerParticipants, 1)
+	assert.Equal(t, "worker", plan.workerParticipants[0].serviceName)
 
-	require.Len(t, runtimePlan.cronJobs, 1)
-	assert.Equal(t, "cron-job", runtimePlan.cronJobs[0].serviceName)
-	assert.Equal(t, "cron-job", runtimePlan.cronJobs[0].jobName)
-	assert.True(t, runtimePlan.cronJobs[0].transient)
+	require.Len(t, plan.cronJobs, 1)
+	assert.Equal(t, "cron-job", plan.cronJobs[0].serviceName)
+	assert.True(t, plan.cronJobs[0].transient)
 }
 
 func TestLifecyclePlanDoesNotResolvePlainServicesDuringPlanning(t *testing.T) {
@@ -171,12 +169,43 @@ func TestLifecyclePlanDoesNotResolveRuntimeParticipantsDuringPlanning(t *testing
 	assert.Zero(t, cronResolutions.Load())
 	assert.NotContains(t, plan.services, "worker")
 	assert.NotContains(t, plan.services, "cron-job")
+	require.Len(t, plan.workerParticipants, 1)
+	require.Len(t, plan.cronJobs, 1)
+	assert.Equal(t, "worker", plan.workerParticipants[0].serviceName)
+	assert.Equal(t, "cron-job", plan.cronJobs[0].serviceName)
+	assert.Zero(t, workerResolutions.Load())
+	assert.Zero(t, cronResolutions.Load())
+}
 
-	runtimePlan := newRuntimeParticipantPlan(c)
-	require.Len(t, runtimePlan.workerParticipants, 1)
-	require.Len(t, runtimePlan.cronJobs, 1)
-	assert.Equal(t, int32(1), workerResolutions.Load())
-	assert.Equal(t, int32(1), cronResolutions.Load())
+func TestAppBuildCachesFullLifecyclePlan(t *testing.T) {
+	app := New()
+
+	require.NoError(t, For[*lifecyclePlanDependency](app.Container()).Named("dependency").
+		ProviderFunc(func(*Container) *lifecyclePlanDependency {
+			return &lifecyclePlanDependency{}
+		}))
+
+	require.NoError(t, For[*lifecyclePlanWorker](app.Container()).Named("worker").
+		Instance(&lifecyclePlanWorker{name: "worker"}))
+
+	require.NoError(t, For[cron.CronJob](app.Container()).Named("cron-job").Transient().
+		ProviderFunc(func(*Container) cron.CronJob {
+			return &lifecyclePlanCronJob{}
+		}))
+
+	require.NoError(t, app.Build())
+
+	plan := app.cachedLifecyclePlan
+	require.NotNil(t, plan)
+	assert.Contains(t, plan.services, "dependency")
+	assert.Equal(t, [][]string{{"dependency"}}, plan.startupOrder)
+	assert.Equal(t, [][]string{{"dependency"}}, plan.shutdownOrder)
+
+	require.Len(t, plan.workerParticipants, 1)
+	assert.Equal(t, "worker", plan.workerParticipants[0].serviceName)
+
+	require.Len(t, plan.cronJobs, 1)
+	assert.Equal(t, "cron-job", plan.cronJobs[0].serviceName)
 }
 
 func flattenLifecycleOrder(order [][]string) []string {


### PR DESCRIPTION
## Summary

- cache the full lifecycle runtime plan during `App.Build()` instead of splitting lifecycle service planning from runtime participant discovery
- keep worker and cron participants as service descriptors during planning, resolving them only when registering runtime participants
- reuse the cached lifecycle plan for start and stop, with a fallback planner for direct stop paths

## Impact

This keeps lifecycle ordering, worker discovery, and cron discovery in one cached plan while preserving lazy runtime participant resolution. Startup and shutdown no longer re-walk the container after build.

## Validation

- `git diff --check`
- `make check`
- `make fmt-check` with temporary `goimports`
- `make lint`
- `go test ./... -count=1`
- `make cover`
