### PR TITLE
[codex] Fail build on invalid runtime participants

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,6 +10,8 @@ The lifecycle plan is distinct from lifecycle execution. Planning decides what s
 
 The lifecycle plan also owns runtime participant classification for App-managed workers, cron jobs, and framework participants such as the event bus and scheduler. Worker supervision remains the worker manager's implementation concern; the lifecycle plan decides which workers the App runtime hands to that manager.
 
+Runtime participant registration is part of the lifecycle plan's policy surface. A classified worker or cron job must resolve and register successfully during `App.Build()`; otherwise the application fails to build with an actionable error instead of silently dropping the participant.
+
 ### Configured module registration
 
 Configured module registration is the shared App-module pattern for wiring a module-owned configuration type into DI. The module owns its public adapter and flags, while the internal configured-module helper owns the repeated mechanics: start from defaults, overlay ProviderValues when available, apply the module's defaulting policy, and validate before exposing the config.

--- a/app_test.go
+++ b/app_test.go
@@ -705,7 +705,7 @@ func (s *AppTestSuite) TestDiscoverCronJobs_InvalidSchedule() {
 	// Invalid schedules fail Build so broken cron jobs are not silently dropped.
 	buildErr := app.Build()
 	s.Require().Error(buildErr)
-	s.Contains(buildErr.Error(), "registering cron job invalid-job")
+	s.Contains(buildErr.Error(), "registering cron job participant invalid-job (job invalid-job)")
 	s.Contains(buildErr.Error(), "invalid schedule")
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -702,9 +702,11 @@ func (s *AppTestSuite) TestDiscoverCronJobs_InvalidSchedule() {
 		})
 	s.Require().NoError(err)
 
-	// Build should log warning for invalid schedule but not fail
-	// (the scheduler handles invalid schedules gracefully)
-	s.Require().NoError(app.Build())
+	// Invalid schedules fail Build so broken cron jobs are not silently dropped.
+	buildErr := app.Build()
+	s.Require().Error(buildErr)
+	s.Contains(buildErr.Error(), "registering cron job invalid-job")
+	s.Contains(buildErr.Error(), "invalid schedule")
 }
 
 func (s *AppTestSuite) TestDiscoverCronJobs_EmptySchedule() {

--- a/cron/doc.go
+++ b/cron/doc.go
@@ -62,6 +62,8 @@
 //
 //	di.For[cron.CronJob](c).Transient().Provider(NewCleanupJob)
 //
+// app.Build() returns an error if a discovered job cannot be resolved, resolves
+// to a value that does not implement CronJob, or returns an invalid schedule.
 // Jobs returning an empty string from Schedule() are not scheduled (soft disable).
 //
 // # Concurrency and Lifecycle

--- a/lifecycle_plan.go
+++ b/lifecycle_plan.go
@@ -227,7 +227,12 @@ func (p *lifecyclePlan) registerWorkers(
 		}
 
 		if regErr := workerMgr.Register(w); regErr != nil {
-			errs = append(errs, fmt.Errorf("registering worker %s: %w", w.Name(), regErr))
+			errs = append(errs, fmt.Errorf(
+				"registering worker participant %s (worker %s): %w",
+				participant.serviceName,
+				w.Name(),
+				regErr,
+			))
 		}
 	}
 
@@ -291,7 +296,12 @@ func (p *lifecyclePlan) registerCronJobs(
 			job.Schedule(),
 			job.Timeout(),
 		); regErr != nil {
-			errs = append(errs, fmt.Errorf("registering cron job %s: %w", job.Name(), regErr))
+			errs = append(errs, fmt.Errorf(
+				"registering cron job participant %s (job %s): %w",
+				participant.serviceName,
+				job.Name(),
+				regErr,
+			))
 		}
 	}
 

--- a/lifecycle_plan.go
+++ b/lifecycle_plan.go
@@ -189,9 +189,9 @@ func (p *lifecyclePlan) registerRuntimeParticipants(
 	}
 
 	errs := make([]error, 0, runtimeParticipantErrorCapacity)
-	p.registerWorkers(container, workerMgr, log)
+	errs = append(errs, p.registerWorkers(container, workerMgr)...)
 	errs = append(errs, p.registerEventBus(workerMgr, eventBus)...)
-	p.registerCronJobs(container, scheduler, log)
+	errs = append(errs, p.registerCronJobs(container, scheduler, log)...)
 	errs = append(errs, p.registerScheduler(workerMgr, scheduler)...)
 	return errs
 }
@@ -199,30 +199,39 @@ func (p *lifecyclePlan) registerRuntimeParticipants(
 func (p *lifecyclePlan) registerWorkers(
 	container *Container,
 	workerMgr *worker.Manager,
-	log *slog.Logger,
-) {
+) []error {
 	if workerMgr == nil {
-		return
+		return nil
 	}
 
+	errs := make([]error, 0, len(p.workerParticipants))
 	for _, participant := range p.workerParticipants {
 		instance, err := container.ResolveByName(participant.serviceName, nil)
 		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"registering worker participant %s: resolve: %w",
+				participant.serviceName,
+				err,
+			))
 			continue
 		}
 
 		w, ok := instance.(worker.Worker)
 		if !ok {
+			errs = append(errs, fmt.Errorf(
+				"registering worker participant %s: resolved %T does not implement worker.Worker",
+				participant.serviceName,
+				instance,
+			))
 			continue
 		}
 
 		if regErr := workerMgr.Register(w); regErr != nil {
-			log.Warn("failed to register worker",
-				"name", w.Name(),
-				"error", regErr,
-			)
+			errs = append(errs, fmt.Errorf("registering worker %s: %w", w.Name(), regErr))
 		}
 	}
+
+	return errs
 }
 
 func (p *lifecyclePlan) registerEventBus(
@@ -243,19 +252,30 @@ func (p *lifecyclePlan) registerCronJobs(
 	container *Container,
 	scheduler *cron.Scheduler,
 	log *slog.Logger,
-) {
+) []error {
 	if scheduler == nil {
-		return
+		return nil
 	}
 
+	errs := make([]error, 0, len(p.cronJobs))
 	for _, participant := range p.cronJobs {
 		instance, err := container.ResolveByName(participant.serviceName, nil)
 		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"registering cron job participant %s: resolve: %w",
+				participant.serviceName,
+				err,
+			))
 			continue
 		}
 
 		job, ok := instance.(cron.CronJob)
 		if !ok {
+			errs = append(errs, fmt.Errorf(
+				"registering cron job participant %s: resolved %T does not implement cron.CronJob",
+				participant.serviceName,
+				instance,
+			))
 			continue
 		}
 
@@ -271,12 +291,11 @@ func (p *lifecyclePlan) registerCronJobs(
 			job.Schedule(),
 			job.Timeout(),
 		); regErr != nil {
-			log.Warn("failed to register cron job",
-				"name", job.Name(),
-				"error", regErr,
-			)
+			errs = append(errs, fmt.Errorf("registering cron job %s: %w", job.Name(), regErr))
 		}
 	}
+
+	return errs
 }
 
 func (p *lifecyclePlan) registerScheduler(

--- a/lifecycle_plan_test.go
+++ b/lifecycle_plan_test.go
@@ -3,6 +3,8 @@ package gaz
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -378,8 +380,35 @@ func TestAppBuildFailsWhenCronScheduleIsInvalid(t *testing.T) {
 
 	err := app.Build()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "registering cron job invalid-cron-job")
+	assert.Contains(t, err.Error(), "registering cron job participant invalid-cron (job invalid-cron-job)")
 	assert.Contains(t, err.Error(), "invalid schedule")
+}
+
+func TestRegisterWorkersErrorIncludesServiceAndWorkerNames(t *testing.T) {
+	c := NewContainer()
+	require.NoError(t, For[*lifecyclePlanWorker](c).Named("worker-binding").
+		Instance(&lifecyclePlanWorker{name: "runtime-worker"}))
+
+	mgr := worker.NewManager(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, mgr.Start(context.Background()))
+	t.Cleanup(func() {
+		require.NoError(t, mgr.Stop(context.Background()))
+	})
+
+	plan := &lifecyclePlan{
+		workerParticipants: []lifecycleWorkerParticipant{{
+			serviceName: "worker-binding",
+		}},
+	}
+
+	errs := plan.registerWorkers(c, mgr)
+	require.Len(t, errs, 1)
+	assert.ErrorIs(t, errs[0], worker.ErrManagerAlreadyRunning)
+	assert.Contains(
+		t,
+		errs[0].Error(),
+		"registering worker participant worker-binding (worker runtime-worker)",
+	)
 }
 
 func flattenLifecycleOrder(order [][]string) []string {

--- a/lifecycle_plan_test.go
+++ b/lifecycle_plan_test.go
@@ -2,6 +2,7 @@ package gaz
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/petabytecl/gaz/cron"
+	"github.com/petabytecl/gaz/worker"
 )
 
 type lifecyclePlanDependency struct{}
@@ -46,6 +48,13 @@ func (j *lifecyclePlanCronJob) Name() string              { return "cron-job" }
 func (j *lifecyclePlanCronJob) Schedule() string          { return "@every 1m" }
 func (j *lifecyclePlanCronJob) Timeout() time.Duration    { return time.Second }
 func (j *lifecyclePlanCronJob) Run(context.Context) error { return nil }
+
+type lifecyclePlanInvalidCronJob struct{}
+
+func (j *lifecyclePlanInvalidCronJob) Name() string              { return "invalid-cron-job" }
+func (j *lifecyclePlanInvalidCronJob) Schedule() string          { return "not-a-schedule" }
+func (j *lifecyclePlanInvalidCronJob) Timeout() time.Duration    { return time.Second }
+func (j *lifecyclePlanInvalidCronJob) Run(context.Context) error { return nil }
 
 type lifecyclePlanLazyPlain struct{}
 
@@ -293,6 +302,84 @@ func TestAppBuildDoesNotResolveLifecycleServices(t *testing.T) {
 	assert.Equal(t, []string{"z-dependency", "a-dependent"}, started)
 
 	require.NoError(t, app.Stop(context.Background()))
+}
+
+func TestAppBuildFailsWhenWorkerParticipantCannotResolve(t *testing.T) {
+	app := New()
+	workerErr := errors.New("worker provider failed")
+
+	require.NoError(t, For[*lifecyclePlanWorker](app.Container()).Named("broken-worker").
+		Provider(func(*Container) (*lifecyclePlanWorker, error) {
+			return nil, workerErr
+		}))
+
+	err := app.Build()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, workerErr)
+	assert.Contains(t, err.Error(), "registering worker participant broken-worker: resolve")
+}
+
+func TestAppBuildFailsWhenWorkerParticipantResolvesWrongType(t *testing.T) {
+	app := New()
+
+	require.NoError(t, For[worker.Worker](app.Container()).Named("nil-worker").
+		ProviderFunc(func(*Container) worker.Worker {
+			return nil
+		}))
+
+	err := app.Build()
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"registering worker participant nil-worker: resolved <nil> does not implement worker.Worker",
+	)
+}
+
+func TestAppBuildFailsWhenCronParticipantCannotResolve(t *testing.T) {
+	app := New()
+	cronErr := errors.New("cron provider failed")
+
+	require.NoError(t, For[cron.CronJob](app.Container()).Named("broken-cron").Transient().
+		Provider(func(*Container) (cron.CronJob, error) {
+			return nil, cronErr
+		}))
+
+	err := app.Build()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cronErr)
+	assert.Contains(t, err.Error(), "registering cron job participant broken-cron: resolve")
+}
+
+func TestAppBuildFailsWhenCronParticipantResolvesWrongType(t *testing.T) {
+	app := New()
+
+	require.NoError(t, For[cron.CronJob](app.Container()).Named("nil-cron").Transient().
+		ProviderFunc(func(*Container) cron.CronJob {
+			return nil
+		}))
+
+	err := app.Build()
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"registering cron job participant nil-cron: resolved <nil> does not implement cron.CronJob",
+	)
+}
+
+func TestAppBuildFailsWhenCronScheduleIsInvalid(t *testing.T) {
+	app := New()
+
+	require.NoError(t, For[cron.CronJob](app.Container()).Named("invalid-cron").Transient().
+		ProviderFunc(func(*Container) cron.CronJob {
+			return &lifecyclePlanInvalidCronJob{}
+		}))
+
+	err := app.Build()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registering cron job invalid-cron-job")
+	assert.Contains(t, err.Error(), "invalid schedule")
 }
 
 func flattenLifecycleOrder(order [][]string) []string {

--- a/worker/doc.go
+++ b/worker/doc.go
@@ -22,6 +22,8 @@
 // Workers are responsible for their own goroutine management. OnStart() must be
 // non-blocking; the worker should spawn its own goroutine for long-running work.
 // OnStop() signals the worker to shut down; the worker decides when to return.
+// app.Build() returns an error if a discovered worker cannot be resolved or
+// resolves to a value that does not implement Worker.
 //
 // Example of a simple worker:
 //

--- a/worker/doc.go
+++ b/worker/doc.go
@@ -22,8 +22,9 @@
 // Workers are responsible for their own goroutine management. OnStart() must be
 // non-blocking; the worker should spawn its own goroutine for long-running work.
 // OnStop() signals the worker to shut down; the worker decides when to return.
-// app.Build() returns an error if a discovered worker cannot be resolved or
-// resolves to a value that does not implement Worker.
+// app.Build() returns an error if a discovered worker cannot be resolved,
+// resolves to a value that does not implement Worker, or cannot be registered
+// with the App's worker manager.
 //
 // Example of a simple worker:
 //


### PR DESCRIPTION
## Summary

- Return build errors when discovered worker participants fail to resolve, resolve to the wrong type, or cannot register with the worker manager.
- Return build errors when discovered cron jobs fail to resolve, resolve to the wrong type, or have invalid schedules.
- Update lifecycle context and worker/cron package docs so runtime participant registration policy matches implementation.

## Impact

Broken worker and cron registrations now fail during `App.Build()` instead of being silently dropped after classification. Empty cron schedules remain a soft-disable path.

## Validation

- `git diff --check`
- `make check`
- `make fmt-check`
- `make lint`
- `go test ./... -count=1`
- `make cover`