### PR TITLE
refactor: deepen the App build sequence

### DIFF
--- a/app_build.go
+++ b/app_build.go
@@ -2,7 +2,6 @@ package gaz
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -131,79 +130,15 @@ func (a *App) Build() error {
 	defer a.mu.Unlock()
 
 	if a.built {
-		return nil // Already built, idempotent
+		return nil
 	}
 
-	// Load configuration first
 	if err := a.loadConfig(); err != nil {
 		return err
 	}
 
-	// Collect any registration errors
-	var errs []error
-	errs = append(errs, a.buildErrors...)
-
-	// Register ProviderValues EARLY so providers can inject it
-	if err := a.registerProviderValuesEarly(); err != nil {
-		errs = append(errs, err)
-	}
-
-	// Initialize Logger BEFORE collecting provider configs
-	// This allows logger config from modules to be used
-	if err := a.initializeLogger(); err != nil {
-		errs = append(errs, err)
-	}
-
-	// Initialize subsystems (WorkerManager, Scheduler, EventBus) after logger
-	if err := a.initializeSubsystems(); err != nil {
-		errs = append(errs, err)
-	}
-
-	// Collect provider configs from registered services
-	// Now providers can inject *ProviderValues as a dependency
-	if err := a.collectProviderConfigs(); err != nil {
-		errs = append(errs, err)
-	}
-
-	// Auto-register health module if config implements HealthConfigProvider
-	// and health module is not already registered
-	if err := a.autoRegisterHealth(); err != nil {
-		errs = append(errs, err)
-	}
-
-	// Delegate to container.Build() for eager instantiation
-	if err := a.container.Build(); err != nil {
-		errs = append(errs, err)
-	}
-
-	if len(errs) == 0 {
-		plan, planErr := newLifecyclePlan(a.container)
-		if planErr != nil {
-			errs = append(errs, planErr)
-		} else {
-			a.cachedLifecyclePlan = plan
-		}
-	}
-
-	if len(errs) == 0 {
-		if resolveErr := a.cachedLifecyclePlan.resolveLifecycleServices(a.container); resolveErr != nil {
-			errs = append(errs, resolveErr)
-		}
-	}
-
-	if len(errs) == 0 {
-		plan := a.cachedLifecyclePlan
-		errs = append(errs, plan.registerRuntimeParticipants(
-			a.container,
-			a.workerMgr,
-			a.eventBus,
-			a.scheduler,
-			a.getLogger(),
-		)...)
-	}
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
+	if err := a.runBuildPhases(); err != nil {
+		return err
 	}
 
 	a.built = true

--- a/build_sequence.go
+++ b/build_sequence.go
@@ -1,0 +1,89 @@
+package gaz
+
+import (
+	"errors"
+	"fmt"
+)
+
+// buildPhase names a unit of work in the build pipeline.
+type buildPhase struct {
+	name  string
+	run   func() error
+	gated bool // only runs if no prior phase produced an error
+}
+
+// buildPhaseOrder returns the named build phases in their required execution
+// order. The ordering contracts documented here are verified by tests.
+//
+// Ordering contracts:
+//   - register-provider-values before collect-provider-configs
+//   - initialize-logger before initialize-subsystems
+//   - build-container before create-lifecycle-plan
+//   - create-lifecycle-plan before resolve-lifecycle-services
+//   - resolve-lifecycle-services before register-runtime-participants
+func (a *App) buildPhaseOrder() []buildPhase {
+	return []buildPhase{
+		{name: "register-provider-values", run: a.registerProviderValuesEarly},
+		{name: "initialize-logger", run: a.initializeLogger},
+		{name: "initialize-subsystems", run: a.initializeSubsystems},
+		{name: "collect-provider-configs", run: a.collectProviderConfigs},
+		{name: "auto-register-health", run: a.autoRegisterHealth},
+		{name: "build-container", run: a.buildContainer},
+		{name: "create-lifecycle-plan", run: a.createLifecyclePlan, gated: true},
+		{name: "resolve-lifecycle-services", run: a.resolveLifecycleServicesStep, gated: true},
+		{name: "register-runtime-participants", run: a.registerRuntimeParticipantsStep, gated: true},
+	}
+}
+
+// runBuildPhases executes the build pipeline in order.
+// Non-gated phases always run and accumulate errors so users see all
+// problems at once. Gated phases only run if no prior error occurred.
+func (a *App) runBuildPhases() error {
+	var errs []error
+	errs = append(errs, a.buildErrors...)
+
+	for _, phase := range a.buildPhaseOrder() {
+		if phase.gated && len(errs) > 0 {
+			break
+		}
+		if err := phase.run(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (a *App) buildContainer() error {
+	if err := a.container.Build(); err != nil {
+		return fmt.Errorf("building container: %w", err)
+	}
+	return nil
+}
+
+func (a *App) createLifecyclePlan() error {
+	plan, err := newLifecyclePlan(a.container)
+	if err != nil {
+		return err
+	}
+	a.cachedLifecyclePlan = plan
+	return nil
+}
+
+func (a *App) resolveLifecycleServicesStep() error {
+	return a.cachedLifecyclePlan.resolveLifecycleServices(a.container)
+}
+
+func (a *App) registerRuntimeParticipantsStep() error {
+	errs := a.cachedLifecyclePlan.registerRuntimeParticipants(
+		a.container,
+		a.workerMgr,
+		a.eventBus,
+		a.scheduler,
+		a.getLogger(),
+	)
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("registering runtime participants: %w", errors.Join(errs...))
+}

--- a/build_sequence_test.go
+++ b/build_sequence_test.go
@@ -46,34 +46,51 @@ func TestBuildPhaseOrder_ContainerBuildBeforeLifecyclePlan(t *testing.T) {
 
 	bc := phaseIndex(phases, "build-container")
 	lp := phaseIndex(phases, "create-lifecycle-plan")
-	rp := phaseIndex(phases, "register-runtime-participants")
 
 	require.NotEqual(t, -1, bc)
 	require.NotEqual(t, -1, lp)
-	require.NotEqual(t, -1, rp)
 	assert.Less(t, bc, lp)
-	assert.Less(t, lp, rp)
+}
+
+func TestBuildPhaseOrder_LifecyclePlanBeforeResolveBeforeParticipants(t *testing.T) {
+	app := New()
+	phases := app.buildPhaseOrder()
+
+	lp := phaseIndex(phases, "create-lifecycle-plan")
+	rs := phaseIndex(phases, "resolve-lifecycle-services")
+	rp := phaseIndex(phases, "register-runtime-participants")
+
+	require.NotEqual(t, -1, lp)
+	require.NotEqual(t, -1, rs)
+	require.NotEqual(t, -1, rp)
+	assert.Less(t, lp, rs)
+	assert.Less(t, rs, rp)
 }
 
 func TestBuildPhaseOrder_GatedPhasesAreAfterNonGated(t *testing.T) {
 	app := New()
 	phases := app.buildPhaseOrder()
 
+	var gatedCount, nonGatedCount int
 	lastNonGated := -1
 	firstGated := len(phases)
 
 	for i, p := range phases {
 		if p.gated {
+			gatedCount++
 			if i < firstGated {
 				firstGated = i
 			}
 		} else {
+			nonGatedCount++
 			if i > lastNonGated {
 				lastNonGated = i
 			}
 		}
 	}
 
+	require.Greater(t, gatedCount, 0, "at least one gated phase must exist")
+	require.Greater(t, nonGatedCount, 0, "at least one non-gated phase must exist")
 	assert.Less(t, lastNonGated, firstGated,
 		"all non-gated phases must precede gated phases")
 }
@@ -89,34 +106,11 @@ func TestRunBuildPhases_GatedPhasesSkippedOnError(t *testing.T) {
 	app := New()
 	app.buildErrors = []error{assert.AnError}
 
-	var ran []string
-	original := app.buildPhaseOrder()
+	err := app.runBuildPhases()
+	require.Error(t, err)
 
-	phases := make([]buildPhase, len(original))
-	for i, p := range original {
-		name := p.name
-		gated := p.gated
-		phases[i] = buildPhase{
-			name:  name,
-			gated: gated,
-			run: func() error {
-				ran = append(ran, name)
-				return nil
-			},
-		}
-	}
-
-	for _, phase := range phases {
-		if phase.gated && len(app.buildErrors) > 0 {
-			break
-		}
-		_ = phase.run()
-	}
-
-	for _, name := range ran {
-		idx := phaseIndex(original, name)
-		require.NotEqual(t, -1, idx)
-		assert.False(t, original[idx].gated,
-			"gated phase %q should not have run", name)
-	}
+	// Verify gated phases did not execute by checking their side effects:
+	// lifecycle plan should be nil because createLifecyclePlan is gated.
+	assert.Nil(t, app.cachedLifecyclePlan,
+		"gated phase create-lifecycle-plan should not have run")
 }

--- a/build_sequence_test.go
+++ b/build_sequence_test.go
@@ -1,0 +1,122 @@
+package gaz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func phaseIndex(phases []buildPhase, name string) int {
+	for i, p := range phases {
+		if p.name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestBuildPhaseOrder_ProviderValuesBeforeCollectConfigs(t *testing.T) {
+	app := New()
+	phases := app.buildPhaseOrder()
+
+	pv := phaseIndex(phases, "register-provider-values")
+	cc := phaseIndex(phases, "collect-provider-configs")
+
+	require.NotEqual(t, -1, pv)
+	require.NotEqual(t, -1, cc)
+	assert.Less(t, pv, cc)
+}
+
+func TestBuildPhaseOrder_LoggerBeforeSubsystems(t *testing.T) {
+	app := New()
+	phases := app.buildPhaseOrder()
+
+	lg := phaseIndex(phases, "initialize-logger")
+	ss := phaseIndex(phases, "initialize-subsystems")
+
+	require.NotEqual(t, -1, lg)
+	require.NotEqual(t, -1, ss)
+	assert.Less(t, lg, ss)
+}
+
+func TestBuildPhaseOrder_ContainerBuildBeforeLifecyclePlan(t *testing.T) {
+	app := New()
+	phases := app.buildPhaseOrder()
+
+	bc := phaseIndex(phases, "build-container")
+	lp := phaseIndex(phases, "create-lifecycle-plan")
+	rp := phaseIndex(phases, "register-runtime-participants")
+
+	require.NotEqual(t, -1, bc)
+	require.NotEqual(t, -1, lp)
+	require.NotEqual(t, -1, rp)
+	assert.Less(t, bc, lp)
+	assert.Less(t, lp, rp)
+}
+
+func TestBuildPhaseOrder_GatedPhasesAreAfterNonGated(t *testing.T) {
+	app := New()
+	phases := app.buildPhaseOrder()
+
+	lastNonGated := -1
+	firstGated := len(phases)
+
+	for i, p := range phases {
+		if p.gated {
+			if i < firstGated {
+				firstGated = i
+			}
+		} else {
+			if i > lastNonGated {
+				lastNonGated = i
+			}
+		}
+	}
+
+	assert.Less(t, lastNonGated, firstGated,
+		"all non-gated phases must precede gated phases")
+}
+
+func TestBuildIdempotent(t *testing.T) {
+	app := New()
+
+	require.NoError(t, app.Build())
+	require.NoError(t, app.Build())
+}
+
+func TestRunBuildPhases_GatedPhasesSkippedOnError(t *testing.T) {
+	app := New()
+	app.buildErrors = []error{assert.AnError}
+
+	var ran []string
+	original := app.buildPhaseOrder()
+
+	phases := make([]buildPhase, len(original))
+	for i, p := range original {
+		name := p.name
+		gated := p.gated
+		phases[i] = buildPhase{
+			name:  name,
+			gated: gated,
+			run: func() error {
+				ran = append(ran, name)
+				return nil
+			},
+		}
+	}
+
+	for _, phase := range phases {
+		if phase.gated && len(app.buildErrors) > 0 {
+			break
+		}
+		_ = phase.run()
+	}
+
+	for _, name := range ran {
+		idx := phaseIndex(original, name)
+		require.NotEqual(t, -1, idx)
+		assert.False(t, original[idx].gated,
+			"gated phase %q should not have run", name)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract nine build phases from inline `Build()` orchestration into a named `buildPhaseOrder()` data structure in `build_sequence.go`
- `Build()` becomes a thin 3-line method: load config, run phases, set built
- Phase ordering contracts are now testable structurally without full integration setup
- Two-tier error model made explicit via `gated` flag: non-gated phases accumulate errors, gated phases (lifecycle plan + runtime participants) abort on prior failure

## Motivation

Priority 2 from `docs/architecture-recommendations.md`. After health auto-registration was extracted (PR #28), this is the next high-leverage slice: it makes the build order testable, auditable, and extensible without touching a monolithic method body.

## Test plan

- [x] `TestBuildPhaseOrder_ProviderValuesBeforeCollectConfigs` — ordering contract
- [x] `TestBuildPhaseOrder_LoggerBeforeSubsystems` — ordering contract
- [x] `TestBuildPhaseOrder_ContainerBuildBeforeLifecyclePlan` — ordering contract
- [x] `TestBuildPhaseOrder_GatedPhasesAreAfterNonGated` — tier separation
- [x] `TestBuildIdempotent` — Build() remains idempotent
- [x] `TestRunBuildPhases_GatedPhasesSkippedOnError` — error gating behavior
- [x] Full test suite passes with race detector
- [x] `make lint` — 0 issues
- [x] `make cover` — 90.8%