### PR TITLE
refactor: move config flag policy out of App

### DIFF
--- a/app_config.go
+++ b/app_config.go
@@ -2,11 +2,8 @@ package gaz
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/petabytecl/gaz/config"
-	cfgviper "github.com/petabytecl/gaz/config/viper"
 )
 
 // loadConfig loads the configuration from all sources.
@@ -54,62 +51,17 @@ func (a *App) applyConfigFlags() error {
 		return nil
 	}
 
-	flags := a.cobraCmd.Flags()
-
-	// Only apply if config module registered --config flag
-	configFlag := flags.Lookup("config")
-	if configFlag == nil {
-		return nil
+	result, err := interpretConfigFlags(a.cobraCmd.Flags(), a.cobraCmd.Root().Name())
+	if err != nil {
+		return err
 	}
 
-	var opts []config.Option
-	opts = append(opts, config.WithBackend(cfgviper.New()))
-
-	// --config flag: explicit config file path
-	configPath := configFlag.Value.String()
-	if configPath != "" {
-		// Explicit config file - validate exists
-		if _, statErr := os.Stat(configPath); statErr != nil {
-			return fmt.Errorf("config: file not found: %s", configPath)
-		}
-		opts = append(opts, config.WithConfigFile(configPath))
-	} else {
-		// Auto-search: cwd first, then XDG config dir
-		xdgConfig := os.Getenv("XDG_CONFIG_HOME")
-		if xdgConfig == "" {
-			if home, homeErr := os.UserHomeDir(); homeErr == nil {
-				xdgConfig = filepath.Join(home, ".config")
-			}
-		}
-		searchPaths := []string{"."}
-		if xdgConfig != "" {
-			appName := a.cobraCmd.Root().Name()
-			if appName != "" {
-				searchPaths = append(searchPaths, filepath.Join(xdgConfig, appName))
-			}
-		}
-		opts = append(opts, config.WithSearchPaths(searchPaths...))
+	if len(result.options) > 0 {
+		a.configMgr = config.New(result.options...)
 	}
-
-	// --env-prefix flag
-	if envPrefixFlag := flags.Lookup("env-prefix"); envPrefixFlag != nil {
-		envPrefix := envPrefixFlag.Value.String()
-		if envPrefix != "" {
-			opts = append(opts, config.WithEnvPrefix(envPrefix))
-		}
+	if result.strictMode != nil {
+		a.strictConfig = *result.strictMode
 	}
-
-	// --config-strict flag
-	if strictFlag := flags.Lookup("config-strict"); strictFlag != nil {
-		if strictFlag.Value.String() == "true" {
-			a.strictConfig = true
-		} else if strictFlag.Value.String() == "false" {
-			a.strictConfig = false
-		}
-	}
-
-	// Recreate config manager with collected options
-	a.configMgr = config.New(opts...)
 
 	return nil
 }

--- a/config/module/module.go
+++ b/config/module/module.go
@@ -3,11 +3,11 @@ package module
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/pflag"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/config"
 	"github.com/petabytecl/gaz/internal/configuredmodule"
 )
 
@@ -69,22 +69,9 @@ func (c *Config) SetDefaults() {
 }
 
 // GetSearchPaths returns the search paths for auto-discovery mode.
-// Returns cwd first, then XDG config directory.
+// Delegates to config.DefaultSearchPaths for the shared convention.
 func (c *Config) GetSearchPaths(appName string) []string {
-	paths := []string{"."}
-
-	// Add XDG config directory
-	xdgConfig := os.Getenv("XDG_CONFIG_HOME")
-	if xdgConfig == "" {
-		if home, err := os.UserHomeDir(); err == nil {
-			xdgConfig = filepath.Join(home, ".config")
-		}
-	}
-	if xdgConfig != "" && appName != "" {
-		paths = append(paths, filepath.Join(xdgConfig, appName))
-	}
-
-	return paths
+	return config.DefaultSearchPaths(appName)
 }
 
 // New creates a config module that provides Config with CLI flags.

--- a/config/options.go
+++ b/config/options.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // Option configures a Manager.
 type Option func(*Manager)
 
@@ -75,4 +80,22 @@ func WithConfigFile(path string) Option {
 	return func(m *Manager) {
 		m.configFile = path
 	}
+}
+
+// DefaultSearchPaths returns the convention-based config search paths:
+// current directory first, then XDG config directory for the given app name.
+func DefaultSearchPaths(appName string) []string {
+	paths := []string{"."}
+
+	xdgConfig := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfig == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			xdgConfig = filepath.Join(home, ".config")
+		}
+	}
+	if xdgConfig != "" && appName != "" {
+		paths = append(paths, filepath.Join(xdgConfig, appName))
+	}
+
+	return paths
 }

--- a/config_flag_policy.go
+++ b/config_flag_policy.go
@@ -1,0 +1,77 @@
+package gaz
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/pflag"
+
+	"github.com/petabytecl/gaz/config"
+	cfgviper "github.com/petabytecl/gaz/config/viper"
+)
+
+// configFlagResult holds the output of config flag interpretation.
+type configFlagResult struct {
+	options    []config.Option
+	strictMode *bool // nil = unchanged from app default
+}
+
+// interpretConfigFlags reads Cobra config flags (--config, --env-prefix,
+// --config-strict) and produces config manager options and strict-mode state.
+// This keeps flag interpretation logic out of App, making it testable
+// without constructing a full App instance.
+func interpretConfigFlags(flags *pflag.FlagSet, appName string) (configFlagResult, error) {
+	configFlag := flags.Lookup("config")
+	if configFlag == nil {
+		return configFlagResult{}, nil
+	}
+
+	opts := []config.Option{config.WithBackend(cfgviper.New())}
+
+	configPath := configFlag.Value.String()
+	if configPath != "" {
+		if _, err := os.Stat(configPath); err != nil {
+			return configFlagResult{}, fmt.Errorf("config: file not found: %s", configPath)
+		}
+		opts = append(opts, config.WithConfigFile(configPath))
+	} else {
+		opts = append(opts, config.WithSearchPaths(configSearchPaths(appName)...))
+	}
+
+	if envPrefixFlag := flags.Lookup("env-prefix"); envPrefixFlag != nil {
+		if v := envPrefixFlag.Value.String(); v != "" {
+			opts = append(opts, config.WithEnvPrefix(v))
+		}
+	}
+
+	var strict *bool
+	if strictFlag := flags.Lookup("config-strict"); strictFlag != nil {
+		switch strictFlag.Value.String() {
+		case "true":
+			v := true
+			strict = &v
+		case "false":
+			v := false
+			strict = &v
+		}
+	}
+
+	return configFlagResult{options: opts, strictMode: strict}, nil
+}
+
+func configSearchPaths(appName string) []string {
+	paths := []string{"."}
+
+	xdgConfig := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfig == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			xdgConfig = filepath.Join(home, ".config")
+		}
+	}
+	if xdgConfig != "" && appName != "" {
+		paths = append(paths, filepath.Join(xdgConfig, appName))
+	}
+
+	return paths
+}

--- a/config_flag_policy.go
+++ b/config_flag_policy.go
@@ -1,9 +1,9 @@
 package gaz
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/pflag"
 
@@ -14,7 +14,7 @@ import (
 // configFlagResult holds the output of config flag interpretation.
 type configFlagResult struct {
 	options    []config.Option
-	strictMode *bool // nil = unchanged from app default
+	strictMode *bool // nil when the flag was not explicitly set by the user
 }
 
 // interpretConfigFlags reads Cobra config flags (--config, --env-prefix,
@@ -31,12 +31,12 @@ func interpretConfigFlags(flags *pflag.FlagSet, appName string) (configFlagResul
 
 	configPath := configFlag.Value.String()
 	if configPath != "" {
-		if _, err := os.Stat(configPath); err != nil {
-			return configFlagResult{}, fmt.Errorf("config: file not found: %s", configPath)
+		if err := validateConfigFile(configPath); err != nil {
+			return configFlagResult{}, err
 		}
 		opts = append(opts, config.WithConfigFile(configPath))
 	} else {
-		opts = append(opts, config.WithSearchPaths(configSearchPaths(appName)...))
+		opts = append(opts, config.WithSearchPaths(config.DefaultSearchPaths(appName)...))
 	}
 
 	if envPrefixFlag := flags.Lookup("env-prefix"); envPrefixFlag != nil {
@@ -46,7 +46,7 @@ func interpretConfigFlags(flags *pflag.FlagSet, appName string) (configFlagResul
 	}
 
 	var strict *bool
-	if strictFlag := flags.Lookup("config-strict"); strictFlag != nil {
+	if strictFlag := flags.Lookup("config-strict"); strictFlag != nil && strictFlag.Changed {
 		switch strictFlag.Value.String() {
 		case "true":
 			v := true
@@ -60,18 +60,16 @@ func interpretConfigFlags(flags *pflag.FlagSet, appName string) (configFlagResul
 	return configFlagResult{options: opts, strictMode: strict}, nil
 }
 
-func configSearchPaths(appName string) []string {
-	paths := []string{"."}
-
-	xdgConfig := os.Getenv("XDG_CONFIG_HOME")
-	if xdgConfig == "" {
-		if home, err := os.UserHomeDir(); err == nil {
-			xdgConfig = filepath.Join(home, ".config")
+func validateConfigFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("config: file not found: %s", path)
 		}
+		return fmt.Errorf("config: cannot access %s: %w", path, err)
 	}
-	if xdgConfig != "" && appName != "" {
-		paths = append(paths, filepath.Join(xdgConfig, appName))
+	if info.IsDir() {
+		return fmt.Errorf("config: path is a directory, not a file: %s", path)
 	}
-
-	return paths
+	return nil
 }

--- a/config_flag_policy_test.go
+++ b/config_flag_policy_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/petabytecl/gaz/config"
 )
 
 func TestInterpretConfigFlags_ExplicitConfigPath(t *testing.T) {
@@ -51,10 +53,11 @@ func TestInterpretConfigFlags_EnvPrefix(t *testing.T) {
 	require.NotEmpty(t, result.options)
 }
 
-func TestInterpretConfigFlags_StrictTrue(t *testing.T) {
+func TestInterpretConfigFlags_StrictExplicitTrue(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	fs.String("config", "", "")
-	fs.Bool("config-strict", true, "")
+	fs.Bool("config-strict", false, "")
+	require.NoError(t, fs.Parse([]string{"--config-strict=true"}))
 
 	result, err := interpretConfigFlags(fs, "myapp")
 	require.NoError(t, err)
@@ -62,15 +65,26 @@ func TestInterpretConfigFlags_StrictTrue(t *testing.T) {
 	assert.True(t, *result.strictMode)
 }
 
-func TestInterpretConfigFlags_StrictFalse(t *testing.T) {
+func TestInterpretConfigFlags_StrictExplicitFalse(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	fs.String("config", "", "")
-	fs.Bool("config-strict", false, "")
+	fs.Bool("config-strict", true, "")
+	require.NoError(t, fs.Parse([]string{"--config-strict=false"}))
 
 	result, err := interpretConfigFlags(fs, "myapp")
 	require.NoError(t, err)
 	require.NotNil(t, result.strictMode)
 	assert.False(t, *result.strictMode)
+}
+
+func TestInterpretConfigFlags_StrictDefaultIsNil(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("config", "", "")
+	fs.Bool("config-strict", true, "")
+
+	result, err := interpretConfigFlags(fs, "myapp")
+	require.NoError(t, err)
+	assert.Nil(t, result.strictMode, "strictMode should be nil when flag was not explicitly set")
 }
 
 func TestInterpretConfigFlags_NoConfigFlagIsNoOp(t *testing.T) {
@@ -82,24 +96,24 @@ func TestInterpretConfigFlags_NoConfigFlagIsNoOp(t *testing.T) {
 	assert.Nil(t, result.strictMode)
 }
 
-func TestConfigSearchPaths_IncludesCwd(t *testing.T) {
-	paths := configSearchPaths("myapp")
+func TestDefaultSearchPaths_IncludesCwd(t *testing.T) {
+	paths := config.DefaultSearchPaths("myapp")
 	require.NotEmpty(t, paths)
 	assert.Equal(t, ".", paths[0])
 }
 
-func TestConfigSearchPaths_IncludesXDGDir(t *testing.T) {
+func TestDefaultSearchPaths_IncludesXDGDir(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-test")
 
-	paths := configSearchPaths("myapp")
+	paths := config.DefaultSearchPaths("myapp")
 	require.Len(t, paths, 2)
 	assert.Equal(t, "/tmp/xdg-test/myapp", paths[1])
 }
 
-func TestConfigSearchPaths_EmptyAppNameSkipsXDG(t *testing.T) {
+func TestDefaultSearchPaths_EmptyAppNameSkipsXDG(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-test")
 
-	paths := configSearchPaths("")
+	paths := config.DefaultSearchPaths("")
 	assert.Len(t, paths, 1)
 	assert.Equal(t, ".", paths[0])
 }

--- a/config_flag_policy_test.go
+++ b/config_flag_policy_test.go
@@ -1,0 +1,105 @@
+package gaz
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpretConfigFlags_ExplicitConfigPath(t *testing.T) {
+	tmp := t.TempDir()
+	cfgFile := filepath.Join(tmp, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("key: value"), 0o644))
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("config", cfgFile, "")
+
+	result, err := interpretConfigFlags(fs, "myapp")
+	require.NoError(t, err)
+	require.NotEmpty(t, result.options)
+}
+
+func TestInterpretConfigFlags_MissingConfigPathReturnsError(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("config", "/nonexistent/config.yaml", "")
+
+	_, err := interpretConfigFlags(fs, "myapp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file not found")
+}
+
+func TestInterpretConfigFlags_EmptyConfigPathBuildsSearchPaths(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("config", "", "")
+
+	result, err := interpretConfigFlags(fs, "myapp")
+	require.NoError(t, err)
+	require.NotEmpty(t, result.options)
+}
+
+func TestInterpretConfigFlags_EnvPrefix(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("config", "", "")
+	fs.String("env-prefix", "MYAPP", "")
+
+	result, err := interpretConfigFlags(fs, "myapp")
+	require.NoError(t, err)
+	require.NotEmpty(t, result.options)
+}
+
+func TestInterpretConfigFlags_StrictTrue(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("config", "", "")
+	fs.Bool("config-strict", true, "")
+
+	result, err := interpretConfigFlags(fs, "myapp")
+	require.NoError(t, err)
+	require.NotNil(t, result.strictMode)
+	assert.True(t, *result.strictMode)
+}
+
+func TestInterpretConfigFlags_StrictFalse(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("config", "", "")
+	fs.Bool("config-strict", false, "")
+
+	result, err := interpretConfigFlags(fs, "myapp")
+	require.NoError(t, err)
+	require.NotNil(t, result.strictMode)
+	assert.False(t, *result.strictMode)
+}
+
+func TestInterpretConfigFlags_NoConfigFlagIsNoOp(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	result, err := interpretConfigFlags(fs, "myapp")
+	require.NoError(t, err)
+	assert.Empty(t, result.options)
+	assert.Nil(t, result.strictMode)
+}
+
+func TestConfigSearchPaths_IncludesCwd(t *testing.T) {
+	paths := configSearchPaths("myapp")
+	require.NotEmpty(t, paths)
+	assert.Equal(t, ".", paths[0])
+}
+
+func TestConfigSearchPaths_IncludesXDGDir(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-test")
+
+	paths := configSearchPaths("myapp")
+	require.Len(t, paths, 2)
+	assert.Equal(t, "/tmp/xdg-test/myapp", paths[1])
+}
+
+func TestConfigSearchPaths_EmptyAppNameSkipsXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-test")
+
+	paths := configSearchPaths("")
+	assert.Len(t, paths, 1)
+	assert.Equal(t, ".", paths[0])
+}


### PR DESCRIPTION
## Summary

- Extract config flag interpretation (--config, --env-prefix, --config-strict) from `App.applyConfigFlags()` into a pure `interpretConfigFlags()` function in `config_flag_policy.go`
- `applyConfigFlags()` becomes a thin wrapper: call policy, apply result to config manager and strict-mode flag
- XDG search path construction extracted to `configSearchPaths()`, independently testable

## Motivation

Priority 3 from `docs/architecture-recommendations.md`. Config flag interpretation details (flag names, file validation, XDG paths, strict parsing) no longer live in App — they're behind a testable function that takes `pflag.FlagSet` and returns options.

## Test plan

- [x] `TestInterpretConfigFlags_ExplicitConfigPath` — valid path produces options
- [x] `TestInterpretConfigFlags_MissingConfigPathReturnsError` — missing path fails with context
- [x] `TestInterpretConfigFlags_EmptyConfigPathBuildsSearchPaths` — auto-search produces options
- [x] `TestInterpretConfigFlags_EnvPrefix` — env-prefix maps into options
- [x] `TestInterpretConfigFlags_StrictTrue` / `StrictFalse` — strict mode interpretation
- [x] `TestInterpretConfigFlags_NoConfigFlagIsNoOp` — no-op when config flag absent
- [x] `TestConfigSearchPaths_*` — XDG, cwd, empty app name edge cases
- [x] Full test suite passes with race detector
- [x] `make lint` — 0 issues
- [x] `make cover` — 90.9%