### PR TITLE
refactor: deepen runtime subsystem initialization

### DIFF
--- a/app_build.go
+++ b/app_build.go
@@ -1,7 +1,6 @@
 package gaz
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -52,36 +51,21 @@ func (a *App) initializeLogger() error {
 // initializeSubsystems creates WorkerManager, Scheduler, EventBus.
 // Called during Build() after logger is initialized.
 func (a *App) initializeSubsystems() error {
-	// Use slog.Default() if Logger is nil (shouldn't happen after initializeLogger)
-	log := a.Logger
-	if log == nil {
-		log = slog.Default()
-	}
-
-	// WorkerManager
-	a.workerMgr = worker.NewManager(log)
-	a.workerMgr.SetCriticalFailHandler(func() {
-		log.Error("critical worker failed, initiating shutdown")
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), a.opts.ShutdownTimeout)
-			defer cancel()
-			if err := a.Stop(ctx); err != nil {
-				log.Warn("critical-fail shutdown completed with errors", slog.Any("error", err))
-			}
-		}()
+	subs, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          a.Logger,
+		container:       a.container,
+		shutdownTimeout: a.opts.ShutdownTimeout,
+		stopFunc:        a.Stop,
 	})
-
-	// Scheduler with cancellable context
-	a.cronCtx, a.cronCancel = context.WithCancel(context.Background())
-	a.scheduler = cron.NewScheduler(a.container, a.cronCtx, log)
-
-	// EventBus
-	a.eventBus = eventbus.New(log)
-
-	// Register EventBus in container
-	if err := For[*eventbus.EventBus](a.container).Instance(a.eventBus); err != nil {
-		return fmt.Errorf("register eventbus: %w", err)
+	if err != nil {
+		return err
 	}
+
+	a.workerMgr = subs.workerMgr
+	a.scheduler = subs.scheduler
+	a.cronCtx = subs.cronCtx
+	a.cronCancel = subs.cronCancel
+	a.eventBus = subs.eventBus
 	return nil
 }
 

--- a/runtime_subsystems.go
+++ b/runtime_subsystems.go
@@ -2,6 +2,7 @@ package gaz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -36,6 +37,16 @@ func newRuntimeSubsystems(deps runtimeSubsystemsDeps) (*runtimeSubsystems, error
 	log := deps.logger
 	if log == nil {
 		log = slog.Default()
+	}
+
+	if deps.container == nil {
+		return nil, errors.New("runtime subsystems: container is required")
+	}
+	if deps.stopFunc == nil {
+		return nil, errors.New("runtime subsystems: stop function is required")
+	}
+	if Has[*eventbus.EventBus](deps.container) {
+		return nil, fmt.Errorf("%w: %s", ErrDIDuplicate, TypeName[*eventbus.EventBus]())
 	}
 
 	mgr := worker.NewManager(log)

--- a/runtime_subsystems.go
+++ b/runtime_subsystems.go
@@ -1,0 +1,74 @@
+package gaz
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/petabytecl/gaz/cron"
+	"github.com/petabytecl/gaz/eventbus"
+	"github.com/petabytecl/gaz/worker"
+)
+
+// runtimeSubsystems owns construction of the App-managed runtime participants:
+// worker manager, cron scheduler, and event bus. Keeping construction in its
+// own module makes it testable without a full App instance.
+type runtimeSubsystems struct {
+	workerMgr  *worker.Manager
+	scheduler  *cron.Scheduler
+	cronCtx    context.Context
+	cronCancel context.CancelFunc
+	eventBus   *eventbus.EventBus
+}
+
+// runtimeSubsystemsDeps are the inputs needed to construct the runtime subsystems.
+type runtimeSubsystemsDeps struct {
+	logger          *slog.Logger
+	container       *Container
+	shutdownTimeout time.Duration
+	stopFunc        func(context.Context) error
+}
+
+// newRuntimeSubsystems creates worker manager, cron scheduler, and event bus.
+// It also registers the event bus in the DI container.
+func newRuntimeSubsystems(deps runtimeSubsystemsDeps) (*runtimeSubsystems, error) {
+	log := deps.logger
+	if log == nil {
+		log = slog.Default()
+	}
+
+	mgr := worker.NewManager(log)
+	mgr.SetCriticalFailHandler(criticalFailHandler(log, deps.shutdownTimeout, deps.stopFunc))
+
+	cronCtx, cronCancel := context.WithCancel(context.Background())
+	sched := cron.NewScheduler(deps.container, cronCtx, log)
+
+	bus := eventbus.New(log)
+
+	if err := For[*eventbus.EventBus](deps.container).Instance(bus); err != nil {
+		cronCancel()
+		return nil, fmt.Errorf("register eventbus: %w", err)
+	}
+
+	return &runtimeSubsystems{
+		workerMgr:  mgr,
+		scheduler:  sched,
+		cronCtx:    cronCtx,
+		cronCancel: cronCancel,
+		eventBus:   bus,
+	}, nil
+}
+
+func criticalFailHandler(log *slog.Logger, timeout time.Duration, stopFunc func(context.Context) error) func() {
+	return func() {
+		log.Error("critical worker failed, initiating shutdown")
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			if err := stopFunc(ctx); err != nil {
+				log.Warn("critical-fail shutdown completed with errors", slog.Any("error", err))
+			}
+		}()
+	}
+}

--- a/runtime_subsystems_test.go
+++ b/runtime_subsystems_test.go
@@ -1,0 +1,108 @@
+package gaz
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/petabytecl/gaz/eventbus"
+)
+
+func TestNewRuntimeSubsystems_RegistersEventBusInDI(t *testing.T) {
+	container := NewContainer()
+
+	subs, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       container,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+	require.NotNil(t, subs.eventBus)
+
+	require.NoError(t, container.Build())
+
+	resolved, resolveErr := Resolve[*eventbus.EventBus](container)
+	require.NoError(t, resolveErr)
+	assert.Same(t, subs.eventBus, resolved)
+}
+
+func TestNewRuntimeSubsystems_NilLoggerFallback(t *testing.T) {
+	container := NewContainer()
+
+	subs, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          nil,
+		container:       container,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+	require.NotNil(t, subs.workerMgr)
+	require.NotNil(t, subs.scheduler)
+	require.NotNil(t, subs.eventBus)
+}
+
+func TestNewRuntimeSubsystems_SchedulerContextCancellable(t *testing.T) {
+	container := NewContainer()
+
+	subs, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       container,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-subs.cronCtx.Done():
+		t.Fatal("context should not be cancelled yet")
+	default:
+	}
+
+	subs.cronCancel()
+
+	select {
+	case <-subs.cronCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("context should be cancelled after cronCancel()")
+	}
+}
+
+func TestCriticalFailHandler_TriggersShutdown(t *testing.T) {
+	var stopCalled atomic.Bool
+
+	handler := criticalFailHandler(
+		slog.Default(),
+		5*time.Second,
+		func(ctx context.Context) error {
+			stopCalled.Store(true)
+			deadline, ok := ctx.Deadline()
+			if ok {
+				assert.WithinDuration(t, time.Now().Add(5*time.Second), deadline, time.Second)
+			}
+			return nil
+		},
+	)
+
+	handler()
+
+	require.Eventually(t, stopCalled.Load, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestNewRuntimeSubsystems_DuplicateEventBusReturnsError(t *testing.T) {
+	container := NewContainer()
+	require.NoError(t, For[*eventbus.EventBus](container).Instance(eventbus.New(slog.Default())))
+
+	_, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       container,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+}

--- a/runtime_subsystems_test.go
+++ b/runtime_subsystems_test.go
@@ -104,5 +104,27 @@ func TestNewRuntimeSubsystems_DuplicateEventBusReturnsError(t *testing.T) {
 		shutdownTimeout: 5 * time.Second,
 		stopFunc:        func(context.Context) error { return nil },
 	})
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrDIDuplicate)
+}
+
+func TestNewRuntimeSubsystems_NilContainerReturnsError(t *testing.T) {
+	_, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       nil,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "container is required")
+}
+
+func TestNewRuntimeSubsystems_NilStopFuncReturnsError(t *testing.T) {
+	_, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       NewContainer(),
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        nil,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stop function is required")
 }


### PR DESCRIPTION
## Summary

- Extract worker manager, cron scheduler, and event bus construction from `initializeSubsystems()` into `newRuntimeSubsystems()` in `runtime_subsystems.go`
- Constructor takes explicit dependencies (logger, container, shutdown timeout, stop function) — testable without full App
- Critical failure callback extracted as `criticalFailHandler()` — independently testable

## Motivation

Priority 4 from `docs/architecture-recommendations.md`. Runtime subsystem construction gains its own locality. Future worker/cron/eventbus changes have a clear place to land. The lifecycle plan keeps owning participant policy while construction is now separate.

## Test plan

- [x] `TestNewRuntimeSubsystems_RegistersEventBusInDI` — EventBus registered exactly once
- [x] `TestNewRuntimeSubsystems_NilLoggerFallback` — safe with nil logger
- [x] `TestNewRuntimeSubsystems_SchedulerContextCancellable` — cronCancel works
- [x] `TestCriticalFailHandler_TriggersShutdown` — callback invokes stop with configured timeout
- [x] `TestNewRuntimeSubsystems_DuplicateEventBusReturnsError` — handles pre-existing registration
- [x] Full test suite passes with race detector
- [x] `make lint` — 0 issues
- [x] `make cover` — 90.8%