### PR TITLE
refactor: extract lifecycle execution from app

### DIFF
--- a/app_run.go
+++ b/app_run.go
@@ -3,12 +3,9 @@ package gaz
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
-	"time"
 )
 
 // Run executes the application lifecycle.
@@ -52,66 +49,7 @@ func (a *App) startServices(ctx context.Context) error {
 		return err
 	}
 
-	a.Logger.InfoContext(ctx, "starting application", "services_count", len(plan.services))
-
-	// Start services layer by layer
-	for _, layer := range plan.startupOrder {
-		var wg sync.WaitGroup
-		errCh := make(chan error, len(layer))
-
-		for _, name := range layer {
-			svc := plan.services[name]
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				start := time.Now()
-				if startErr := svc.Start(ctx); startErr != nil {
-					a.Logger.ErrorContext(
-						ctx,
-						"failed to start service",
-						"name", name,
-						"error", startErr,
-					)
-					errCh <- fmt.Errorf("starting service %s: %w", name, startErr)
-				} else {
-					a.Logger.InfoContext(
-						ctx,
-						"service started",
-						"name", name,
-						"duration", time.Since(start),
-					)
-				}
-			}()
-		}
-		wg.Wait()
-		close(errCh)
-
-		// Drain all errors — multiple services in the same layer may fail.
-		var startupErrors []error
-		for e := range errCh {
-			startupErrors = append(startupErrors, e)
-		}
-		if len(startupErrors) > 0 {
-			startupErr := errors.Join(startupErrors...)
-			// Rollback: stop everything we started.
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), a.opts.ShutdownTimeout)
-			defer cancel()
-			stopErr := a.Stop(shutdownCtx)
-			return errors.Join(startupErr, stopErr)
-		}
-	}
-
-	// Start workers after all services started
-	a.Logger.InfoContext(ctx, "starting workers")
-	if workerErr := a.workerMgr.Start(ctx); workerErr != nil {
-		// Rollback
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), a.opts.ShutdownTimeout)
-		defer cancel()
-		stopErr := a.Stop(shutdownCtx)
-		return errors.Join(fmt.Errorf("starting workers: %w", workerErr), stopErr)
-	}
-
-	return nil
+	return a.lifecycleExecutor(plan).Start(ctx, a.Stop)
 }
 
 // waitForShutdownSignal blocks until a shutdown trigger (signal, context cancel, or Stop call).
@@ -149,19 +87,23 @@ func (a *App) handleSignalShutdown(
 	sig os.Signal,
 	sigCh <-chan os.Signal,
 ) error {
-	// Log hint message about force exit option
-	a.Logger.InfoContext(ctx, "Shutting down gracefully...", "hint", "Ctrl+C again to force")
+	if sig == os.Interrupt {
+		a.Logger.InfoContext(ctx, "Shutting down gracefully...", "hint", "Ctrl+C again to force")
+	} else {
+		a.Logger.InfoContext(ctx, "Shutting down gracefully...", "signal", sig.String())
+	}
 
 	// Create shutdown context
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), a.opts.ShutdownTimeout)
 	defer cancel()
 
-	// Channel to receive shutdown result
-	shutdownDone := make(chan error, 1)
+	shutdownErr := make(chan error, 1)
+	shutdownDone := make(chan struct{})
 
 	// Start graceful shutdown in goroutine so we can continue listening for signals
 	go func() {
-		shutdownDone <- a.Stop(shutdownCtx)
+		defer close(shutdownDone)
+		shutdownErr <- a.Stop(shutdownCtx)
 	}()
 
 	// If SIGINT, spawn force-exit watcher goroutine.
@@ -185,7 +127,7 @@ func (a *App) handleSignalShutdown(
 	}
 
 	// Wait for shutdown to complete
-	err := <-shutdownDone
+	err := <-shutdownErr
 	// Ensure watcher goroutine exits before returning, so that
 	// defer signal.Stop(sigCh) in the caller runs after the watcher.
 	<-watcherDone

--- a/app_shutdown.go
+++ b/app_shutdown.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-
-	"github.com/petabytecl/gaz/di"
 )
 
 // Stop initiates graceful shutdown of the application.
@@ -71,20 +69,8 @@ func (a *App) doStop(ctx context.Context) error {
 	}
 
 	var errs []error
-
-	// Get logger safely (uses slog.Default() if nil)
-	log := a.getLogger()
-
-	// Stop workers first (they may depend on services)
-	log.InfoContext(ctx, "stopping workers")
-	if a.workerMgr != nil {
-		if workerStopErr := a.workerMgr.Stop(ctx); workerStopErr != nil {
-			errs = append(errs, fmt.Errorf("stopping workers: %w", workerStopErr))
-		}
-	}
-
-	if serviceStopErr := a.stopServices(ctx, plan.shutdownOrder, plan.services); serviceStopErr != nil {
-		errs = append(errs, serviceStopErr)
+	if stopErr := a.lifecycleExecutor(plan).Stop(ctx); stopErr != nil {
+		errs = append(errs, stopErr)
 	}
 
 	// Close logger file handle (if any) — after all services stopped, before exit
@@ -113,83 +99,4 @@ func (a *App) doStop(ctx context.Context) error {
 		return errors.Join(errs...)
 	}
 	return nil
-}
-
-// stopServices stops services sequentially with per-hook timeout and blame logging.
-func (a *App) stopServices(
-	ctx context.Context,
-	order [][]string,
-	services map[string]di.ServiceWrapper,
-) error {
-	var errs []error
-
-	// Stop services layer by layer, sequentially within each layer
-	for _, layer := range order {
-		for _, name := range layer {
-			svc := services[name]
-
-			// Create per-hook timeout context
-			timeout := a.opts.PerHookTimeout
-			hookCtx, cancel := context.WithTimeout(ctx, timeout)
-
-			// Run hook in goroutine so we can detect timeout
-			start := time.Now()
-			errCh := make(chan error, 1)
-			go func() {
-				errCh <- svc.Stop(hookCtx)
-			}()
-
-			// Wait for hook completion or timeout
-			select {
-			case stopErr := <-errCh:
-				cancel()
-				elapsed := time.Since(start)
-				if stopErr != nil {
-					a.Logger.ErrorContext(
-						ctx,
-						"failed to stop service",
-						"name", name,
-						"error", stopErr,
-						"elapsed", elapsed,
-					)
-					errs = append(errs, fmt.Errorf("stopping service %s: %w", name, stopErr))
-				} else {
-					a.Logger.InfoContext(
-						ctx,
-						"service stopped",
-						"name", name,
-						"duration", elapsed,
-					)
-				}
-			case <-hookCtx.Done():
-				cancel()
-				elapsed := time.Since(start)
-				// Blame logging: hook exceeded timeout
-				a.logBlame(name, timeout, elapsed)
-				errs = append(
-					errs,
-					fmt.Errorf("stopping service %s: %w", name, context.DeadlineExceeded),
-				)
-				// Continue to next hook (don't wait for the timed-out hook)
-			}
-		}
-	}
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
-}
-
-// logBlame logs blame information when a hook exceeds its timeout.
-// Uses Logger first, falls back to stderr if Logger fails.
-func (a *App) logBlame(hookName string, timeout, elapsed time.Duration) {
-	msg := fmt.Sprintf("shutdown: %s exceeded %s timeout (elapsed: %s)", hookName, timeout, elapsed)
-
-	// Try structured logger first
-	if a.Logger != nil {
-		a.Logger.Error(msg, "hook", hookName, "timeout", timeout, "elapsed", elapsed)
-	}
-	// Always write to stderr as fallback (guaranteed output even if logger is broken)
-	_, _ = fmt.Fprintln(os.Stderr, msg)
 }

--- a/lifecycle_executor.go
+++ b/lifecycle_executor.go
@@ -87,7 +87,7 @@ func (e *lifecycleExecutor) startLayer(ctx context.Context, layer []string) erro
 
 	for _, name := range layer {
 		svc := e.plan.services[name]
-		go func() {
+		go func(name string, svc di.ServiceWrapper) {
 			defer func() { doneCh <- struct{}{} }()
 			start := time.Now()
 			if err := svc.Start(ctx); err != nil {
@@ -106,7 +106,7 @@ func (e *lifecycleExecutor) startLayer(ctx context.Context, layer []string) erro
 				"name", name,
 				"duration", time.Since(start),
 			)
-		}()
+		}(name, svc)
 	}
 
 	for range layer {

--- a/lifecycle_executor.go
+++ b/lifecycle_executor.go
@@ -1,0 +1,221 @@
+package gaz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/petabytecl/gaz/di"
+	"github.com/petabytecl/gaz/worker"
+)
+
+// lifecycleExecutor owns service and worker execution for a resolved
+// lifecycle plan. App remains responsible for build state, signal handling,
+// and one-shot shutdown orchestration.
+type lifecycleExecutor struct {
+	plan            *lifecyclePlan
+	logger          *slog.Logger
+	workerMgr       *worker.Manager
+	shutdownTimeout time.Duration
+	perHookTimeout  time.Duration
+}
+
+type lifecycleExecutorDeps struct {
+	plan            *lifecyclePlan
+	logger          *slog.Logger
+	workerMgr       *worker.Manager
+	shutdownTimeout time.Duration
+	perHookTimeout  time.Duration
+}
+
+func newLifecycleExecutor(deps lifecycleExecutorDeps) *lifecycleExecutor {
+	log := deps.logger
+	if log == nil {
+		log = slog.Default()
+	}
+
+	return &lifecycleExecutor{
+		plan:            deps.plan,
+		logger:          log,
+		workerMgr:       deps.workerMgr,
+		shutdownTimeout: deps.shutdownTimeout,
+		perHookTimeout:  deps.perHookTimeout,
+	}
+}
+
+func (a *App) lifecycleExecutor(plan *lifecyclePlan) *lifecycleExecutor {
+	return newLifecycleExecutor(lifecycleExecutorDeps{
+		plan:            plan,
+		logger:          a.getLogger(),
+		workerMgr:       a.workerMgr,
+		shutdownTimeout: a.opts.ShutdownTimeout,
+		perHookTimeout:  a.opts.PerHookTimeout,
+	})
+}
+
+// Start starts services layer by layer in parallel, then starts workers.
+// On failure at any stage it rolls back through the supplied stop function.
+func (e *lifecycleExecutor) Start(
+	ctx context.Context,
+	rollback func(context.Context) error,
+) error {
+	e.logger.InfoContext(ctx, "starting application", "services_count", len(e.plan.services))
+
+	for _, layer := range e.plan.startupOrder {
+		if err := e.startLayer(ctx, layer); err != nil {
+			return e.withRollback(err, rollback)
+		}
+	}
+
+	e.logger.InfoContext(ctx, "starting workers")
+	if e.workerMgr == nil {
+		return nil
+	}
+	if err := e.workerMgr.Start(ctx); err != nil {
+		return e.withRollback(fmt.Errorf("starting workers: %w", err), rollback)
+	}
+
+	return nil
+}
+
+func (e *lifecycleExecutor) startLayer(ctx context.Context, layer []string) error {
+	errCh := make(chan error, len(layer))
+	doneCh := make(chan struct{})
+
+	for _, name := range layer {
+		svc := e.plan.services[name]
+		go func() {
+			defer func() { doneCh <- struct{}{} }()
+			start := time.Now()
+			if err := svc.Start(ctx); err != nil {
+				e.logger.ErrorContext(
+					ctx,
+					"failed to start service",
+					"name", name,
+					"error", err,
+				)
+				errCh <- fmt.Errorf("starting service %s: %w", name, err)
+				return
+			}
+			e.logger.InfoContext(
+				ctx,
+				"service started",
+				"name", name,
+				"duration", time.Since(start),
+			)
+		}()
+	}
+
+	for range layer {
+		<-doneCh
+	}
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (e *lifecycleExecutor) withRollback(
+	startupErr error,
+	rollback func(context.Context) error,
+) error {
+	if rollback == nil {
+		return startupErr
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), e.shutdownTimeout)
+	defer cancel()
+	return errors.Join(startupErr, rollback(shutdownCtx))
+}
+
+// Stop stops workers first, then lifecycle services in shutdown order.
+func (e *lifecycleExecutor) Stop(ctx context.Context) error {
+	var errs []error
+
+	e.logger.InfoContext(ctx, "stopping workers")
+	if e.workerMgr != nil {
+		if err := e.workerMgr.Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("stopping workers: %w", err))
+		}
+	}
+
+	if err := e.stopServices(ctx, e.plan.shutdownOrder, e.plan.services); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+func (e *lifecycleExecutor) stopServices(
+	ctx context.Context,
+	order [][]string,
+	services map[string]di.ServiceWrapper,
+) error {
+	var errs []error
+
+	for _, layer := range order {
+		for _, name := range layer {
+			if err := e.stopService(ctx, name, services[name]); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (e *lifecycleExecutor) stopService(
+	ctx context.Context,
+	name string,
+	svc di.ServiceWrapper,
+) error {
+	timeout := e.perHookTimeout
+	hookCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	start := time.Now()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- svc.Stop(hookCtx)
+	}()
+
+	select {
+	case err := <-errCh:
+		cancel()
+		elapsed := time.Since(start)
+		if err != nil {
+			e.logger.ErrorContext(
+				ctx,
+				"failed to stop service",
+				"name", name,
+				"error", err,
+				"elapsed", elapsed,
+			)
+			return fmt.Errorf("stopping service %s: %w", name, err)
+		}
+		e.logger.InfoContext(
+			ctx,
+			"service stopped",
+			"name", name,
+			"duration", elapsed,
+		)
+		return nil
+	case <-hookCtx.Done():
+		cancel()
+		elapsed := time.Since(start)
+		e.logBlame(name, timeout, elapsed)
+		return fmt.Errorf("stopping service %s: %w", name, context.DeadlineExceeded)
+	}
+}
+
+func (e *lifecycleExecutor) logBlame(hookName string, timeout, elapsed time.Duration) {
+	msg := fmt.Sprintf("shutdown: %s exceeded %s timeout (elapsed: %s)", hookName, timeout, elapsed)
+
+	e.logger.Error(msg, "hook", hookName, "timeout", timeout, "elapsed", elapsed)
+	_, _ = fmt.Fprintln(os.Stderr, msg)
+}

--- a/lifecycle_executor_test.go
+++ b/lifecycle_executor_test.go
@@ -1,0 +1,120 @@
+package gaz
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/petabytecl/gaz/di"
+)
+
+type executorServiceWrapper struct {
+	name  string
+	start func(context.Context) error
+	stop  func(context.Context) error
+}
+
+func (s *executorServiceWrapper) Name() string      { return s.name }
+func (s *executorServiceWrapper) TypeName() string  { return s.name }
+func (s *executorServiceWrapper) IsEager() bool     { return false }
+func (s *executorServiceWrapper) IsTransient() bool { return false }
+func (s *executorServiceWrapper) GetInstance(
+	_ *di.Container,
+	_ []string,
+) (any, error) {
+	return nil, nil
+}
+
+func (s *executorServiceWrapper) Start(ctx context.Context) error {
+	if s.start == nil {
+		return nil
+	}
+	return s.start(ctx)
+}
+
+func (s *executorServiceWrapper) Stop(ctx context.Context) error {
+	if s.stop == nil {
+		return nil
+	}
+	return s.stop(ctx)
+}
+func (s *executorServiceWrapper) HasLifecycle() bool        { return true }
+func (s *executorServiceWrapper) ServiceType() reflect.Type { return nil }
+func (s *executorServiceWrapper) Groups() []string          { return nil }
+
+func TestLifecycleExecutorStartRollsBackOnLayerFailure(t *testing.T) {
+	startErr := errors.New("start failed")
+	rollbackErr := errors.New("rollback failed")
+	rollbackCalled := false
+
+	executor := newLifecycleExecutor(lifecycleExecutorDeps{
+		plan: &lifecyclePlan{
+			services: map[string]di.ServiceWrapper{
+				"A": &executorServiceWrapper{
+					name:  "A",
+					start: func(context.Context) error { return startErr },
+				},
+			},
+			startupOrder:  [][]string{{"A"}},
+			shutdownOrder: [][]string{{"A"}},
+		},
+		logger:          testLifecycleExecutorLogger(),
+		shutdownTimeout: time.Second,
+		perHookTimeout:  time.Second,
+	})
+
+	err := executor.Start(context.Background(), func(context.Context) error {
+		rollbackCalled = true
+		return rollbackErr
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "starting service A")
+	require.ErrorIs(t, err, startErr)
+	require.ErrorIs(t, err, rollbackErr)
+	require.True(t, rollbackCalled)
+}
+
+func TestLifecycleExecutorStopUsesShutdownOrder(t *testing.T) {
+	var stopped []string
+	services := map[string]di.ServiceWrapper{
+		"A": &executorServiceWrapper{
+			name: "A",
+			stop: func(context.Context) error {
+				stopped = append(stopped, "A")
+				return nil
+			},
+		},
+		"B": &executorServiceWrapper{
+			name: "B",
+			stop: func(context.Context) error {
+				stopped = append(stopped, "B")
+				return nil
+			},
+		},
+	}
+
+	executor := newLifecycleExecutor(lifecycleExecutorDeps{
+		plan: &lifecyclePlan{
+			services:      services,
+			shutdownOrder: [][]string{{"B"}, {"A"}},
+		},
+		logger:         testLifecycleExecutorLogger(),
+		perHookTimeout: time.Second,
+	})
+
+	err := executor.Stop(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"B", "A"}, stopped)
+}
+
+func testLifecycleExecutorLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -499,6 +500,34 @@ func (s *ShutdownTestSuite) TestFirstSIGINTLogsHint() {
 	time.Sleep(10 * time.Millisecond) // required: goroutine cleanup between signal test iterations
 }
 
+func (s *ShutdownTestSuite) TestHandleSIGINTReturnsAfterGracefulShutdown() {
+	app := s.createAppWithSlowHook(10*time.Millisecond, time.Second, time.Second)
+
+	logBuf := &syncBuffer{}
+	handler := slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	app.Logger = slog.New(handler)
+	app.loggerInitialized = true
+
+	err := app.Build()
+	s.Require().NoError(err)
+
+	sigCh := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- app.handleSignalShutdown(context.Background(), os.Interrupt, sigCh)
+	}()
+
+	select {
+	case runErr := <-done:
+		s.Require().NoError(runErr)
+	case <-time.After(500 * time.Millisecond):
+		s.Fail("SIGINT graceful shutdown should return without a second signal")
+	}
+
+	s.False(s.exitCalled.Load(), "exitFunc should not be called for graceful shutdown")
+	s.Contains(logBuf.String(), "Ctrl+C again", "SIGINT should log force-exit hint")
+}
+
 // TestDoubleSIGINTForcesImmediateExit verifies that a second SIGINT
 // triggers immediate exitFunc(1) without waiting for graceful shutdown.
 func (s *ShutdownTestSuite) TestDoubleSIGINTForcesImmediateExit() {
@@ -607,6 +636,7 @@ func (s *ShutdownTestSuite) TestSIGTERMDoesNotEnableDoubleSignal() {
 	// SIGTERM should still log the shutdown message but the hint is for interactive use
 	logOutput := s.logBuffer.String()
 	s.Contains(logOutput, "Shutting down gracefully", "SIGTERM should trigger graceful shutdown")
+	s.NotContains(logOutput, "Ctrl+C again", "SIGTERM should not log the SIGINT force-exit hint")
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- move lifecycle startup, rollback, worker stop, and service stop execution into a private lifecycleExecutor
- keep App focused on build state, run state, and signal orchestration
- fix the SIGINT graceful-shutdown race by separating shutdown result delivery from watcher completion

## Tests
- git diff --check
- go run golang.org/x/tools/cmd/goimports@latest -l .
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make check
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make lint
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... -count=1
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make cover (91.0%)
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make test