### PR TITLE
[codex] Fix gRPC Vanguard bridge timing

### DIFF
--- a/docs/architecture-recommendations.md
+++ b/docs/architecture-recommendations.md
@@ -1,0 +1,305 @@
+# Architecture Recommendations Backlog
+
+Last updated: 2026-05-22
+
+This document captures the remaining architecture recommendations for `gaz` after the merged lifecycle/config refactor series. It is meant as a resume point for future Codex sessions.
+
+Use the vocabulary in `CONTEXT.md`:
+
+- A **lifecycle plan** owns runtime policy: which services participate, which runtime participants are handed to App-managed managers, and what startup/shutdown order is used.
+- **Configured module registration** owns the shared rule for module-owned config values.
+- Architecture recommendations should deepen modules: put policy behind smaller interfaces, improve locality, and keep behavior testable through the public or private module seam.
+
+## Current Baseline
+
+Already completed:
+
+- Lifecycle plan ownership was deepened.
+- ConfigProvider declaration intake was separated from App orchestration.
+- Configured module registration was centralized under `internal/configuredmodule`.
+- Runtime participant classification moved into the lifecycle plan.
+- Worker and cron participant registration now fails `App.Build()` when a participant cannot resolve, resolves to the wrong type, or cannot register.
+
+Quality gate expectation for future PRs:
+
+- `git diff --check`
+- `make check`
+- `make fmt-check`, or `go run golang.org/x/tools/cmd/goimports@latest -l .` when the local `goimports` shim is broken
+- `make lint`
+- `go test ./... -count=1`
+- `make cover`
+- Push, then monitor GitHub Actions and CodeQL for the pushed SHA until green.
+
+## Priority 1: Extract Health Auto-Registration Policy
+
+Recommendation strength: Strong
+
+Files:
+
+- `app_build.go`
+- `health/config_provider.go`
+- `health/module/module.go`
+- `app_use.go`
+- `tests/health_test.go`
+- `health/module/module_test.go`
+
+Problem:
+
+`App.Build()` still owns health-specific feature policy. It detects `health.HealthConfigProvider`, registers `health.Config`, builds an inline health module, applies it, and mutates `a.modules`.
+
+There is also a module identity mismatch worth fixing in the same slice: `health/module.New()` returns a gaz module named `health-flags`, while the App auto-registration path checks `a.modules["health"]`. That means explicit health-module usage and automatic `HealthConfigProvider` usage do not share one obvious ownership marker.
+
+Solution:
+
+Move the health auto-registration rule into a dedicated private module, for example `health_auto_registration.go`, with one small App-facing method. Keep the public behavior the same:
+
+- If `configTarget` implements `health.HealthConfigProvider`, the health module should be registered automatically.
+- If the health module was explicitly applied, auto-registration should be skipped cleanly.
+- If health config or module application fails, `App.Build()` should return an actionable error.
+
+Benefits:
+
+- `App.Build()` becomes orchestration again, not a feature-policy host.
+- Health behavior gains locality: config-provider detection, module identity, and duplicate-avoidance rules live together.
+- Tests can target the health auto-registration policy directly instead of testing it only through the full App build path.
+
+Suggested tests:
+
+- `HealthConfigProvider` auto-registers `health.Config`, `*health.Manager`, `*health.ShutdownCheck`, and `*health.ManagementServer`.
+- Explicit `health/module.New()` plus a `HealthConfigProvider` does not double-apply health providers.
+- Auto-registration propagates `health.Config` registration failure with useful context.
+- Auto-registration preserves current integration test behavior in `tests/health_test.go`.
+
+Why next:
+
+This is the smallest remaining high-leverage slice. It removes feature-specific policy from `App.Build()` and addresses a real naming mismatch without requiring a broader build pipeline redesign.
+
+## Priority 2: Deepen the App Build Sequence
+
+Recommendation strength: Strong, after Priority 1
+
+Files:
+
+- `app_build.go`
+- `app_config.go`
+- `provider_config_intake.go`
+- `lifecycle_plan.go`
+- `app_test.go`
+
+Problem:
+
+`App.Build()` still coordinates too many policies in one method:
+
+- config loading
+- ProviderValues registration
+- logger initialization
+- runtime subsystem initialization
+- ConfigProvider intake
+- health auto-registration
+- container build
+- lifecycle plan creation
+- runtime participant registration
+
+Some of these are already deeper modules, but the sequence itself is still implicit in the method body. When a future change needs to reorder one step, the caller has to understand the entire build pipeline.
+
+Solution:
+
+After health auto-registration is extracted, introduce a private build-sequence module that names the phases and keeps ordering constraints explicit. This does not need a public interface. The goal is a private seam that makes the build order testable and easier to audit.
+
+Benefits:
+
+- Better locality for build ordering rules.
+- Easier tests for "phase X runs before phase Y" without full integration setup.
+- `App.Build()` becomes a thin orchestration call that aggregates errors.
+
+Suggested tests:
+
+- ProviderValues register before ConfigProvider services are resolved.
+- Logger initializes before runtime subsystems.
+- Container build happens before lifecycle plan runtime participant registration.
+- Build remains idempotent after success.
+
+## Priority 3: Move Config Flag Application Policy Out Of App
+
+Recommendation strength: Worth exploring
+
+Files:
+
+- `app_config.go`
+- `config/module/module.go`
+- `config/manager.go`
+- `cobra_flags.go`
+- `app_test.go`
+
+Problem:
+
+`applyConfigFlags()` lives in App and knows the config module flag names, config-file existence policy, XDG search-path behavior, env-prefix behavior, and strict-mode parsing. That makes the App core responsible for details that feel closer to configured module registration and config infrastructure.
+
+Solution:
+
+Create a private config flag policy module that interprets the Cobra flags and returns config manager options plus strict-mode settings. App should still decide when to call it, but not know the details of every config flag.
+
+Benefits:
+
+- Better locality for config/Cobra behavior.
+- Easier focused tests for flag interpretation without building a full App.
+- Less risk that future config module changes require editing App internals.
+
+Suggested tests:
+
+- Explicit `--config` path validates file existence and feeds `config.WithConfigFile`.
+- Empty config path builds the current search path list.
+- `--env-prefix` maps into config options.
+- `--config-strict=false` disables strict config.
+
+## Priority 4: Deepen Runtime Subsystem Initialization
+
+Recommendation strength: Worth exploring
+
+Files:
+
+- `app_build.go`
+- `app_shutdown.go`
+- `lifecycle_plan.go`
+- `worker/manager.go`
+- `cron/scheduler.go`
+- `eventbus/eventbus.go`
+
+Problem:
+
+`initializeSubsystems()` creates the worker manager, cron scheduler context, scheduler, event bus, critical-worker failure hook, and EventBus DI registration. This is runtime subsystem policy, not just App construction.
+
+Solution:
+
+Introduce a private runtime-subsystems module that owns the App-managed runtime participants:
+
+- worker manager
+- cron scheduler and cancellation context
+- framework event bus
+- critical worker failure callback
+
+Do not change public APIs in the first slice. Keep App as the owner of execution, but move construction and registration policy behind one private module.
+
+Benefits:
+
+- Runtime subsystem lifecycle becomes easier to test without invoking the whole App.
+- The lifecycle plan keeps owning participant policy, while runtime subsystem construction gains its own locality.
+- Future worker/cron/eventbus changes have a clear place to land.
+
+Suggested tests:
+
+- EventBus is registered exactly once in DI.
+- Scheduler context is cancelled on `Stop()`.
+- Critical worker failure triggers App shutdown with the configured shutdown timeout.
+- Nil logger fallback remains safe.
+
+## Priority 5: Separate Lifecycle Execution From Signal Handling
+
+Recommendation strength: Worth exploring
+
+Files:
+
+- `app_run.go`
+- `app_shutdown.go`
+- `cobra.go`
+- `lifecycle_plan.go`
+- `shutdown_test.go`
+- `cobra_test.go`
+
+Problem:
+
+Startup, rollback, shutdown, signal waiting, double-SIGINT behavior, and Cobra bootstrap all live close together in App methods. Prior work already made startup paths share `startServices()`, so this is less urgent than the build and health work.
+
+Solution:
+
+After the build/runtime subsystem slices, consider a private lifecycle executor module. It would execute a lifecycle plan with logger, worker manager, shutdown timeout, and per-hook timeout supplied by App. Signal handling can remain in App unless it also becomes a source of friction.
+
+Benefits:
+
+- Startup and shutdown execution rules become a smaller test surface.
+- Cobra and non-Cobra paths can share more behavior without duplicating run-state details.
+- Rollback behavior becomes easier to reason about.
+
+Suggested tests:
+
+- Startup layer failure rolls back already-started services.
+- Worker manager start failure rolls back services.
+- Per-hook timeout records blame and continues.
+- Global shutdown timeout still force-exits through `exitFunc`.
+
+## Priority 6: Rationalize Feature Module Identity
+
+Recommendation strength: Worth exploring
+
+Files:
+
+- `app_use.go`
+- `module_builder.go`
+- `health/module/module.go`
+- `logger/module/module.go`
+- `config/module.go`
+
+Problem:
+
+Feature modules do not currently have a clear naming convention for "feature is installed" versus "flags adapter is installed". Health exposes this most clearly: `health/module.New()` uses the module name `health-flags`, while App auto-registration checks `health`.
+
+Solution:
+
+Define a convention for module identity. A feature module should expose one stable identity for duplicate detection and auto-registration skip logic. If flags are a separate adapter, encode that deliberately instead of relying on ad hoc string checks.
+
+Benefits:
+
+- Auto-registration rules can reliably detect explicit feature registration.
+- Duplicate module behavior becomes less surprising.
+- Future modules can follow one convention.
+
+Suggested tests:
+
+- Applying a module twice still reports duplicate module errors.
+- Feature auto-registration skips when the equivalent explicit module is already present.
+- Child module identity remains visible for duplicate detection.
+
+## Priority 7: Decide Whether `config.NewModule()` Should Exist
+
+Recommendation strength: Speculative
+
+Files:
+
+- `config/module.go`
+- `config/module_test.go`
+- `docs/configuration.md`
+- `docs/concepts.md`
+
+Problem:
+
+`config.NewModule()` is currently a placeholder. The deletion test suggests it is shallow: deleting it would remove little behavior, but the public API may already imply that it has meaning.
+
+Solution:
+
+Make an explicit decision:
+
+- Give it real behavior, such as registering config infrastructure or a documented config manager adapter.
+- Or document it as deprecated/no-op compatibility and stop presenting it as an advanced module.
+
+Benefits:
+
+- Removes a misleading public module.
+- Prevents future architecture reviews from treating a placeholder as a real seam.
+- Improves documentation honesty.
+
+Suggested tests:
+
+- If kept: assert the concrete behavior it owns.
+- If deprecated/no-op: assert it remains harmless and update docs to be explicit.
+
+## Suggested Resume Order
+
+1. Create branch from updated `main`.
+2. Implement Priority 1 only.
+3. Run local gates.
+4. Push and monitor remote CI and CodeQL.
+5. Address review comments and resolve conversations.
+6. Rebase/pull `main` after merge.
+7. Continue with Priority 2.
+
+Avoid doing Priorities 2-6 in one PR. The App runtime is central; smaller PRs make review comments and CI failures easier to isolate.

--- a/server/module_test.go
+++ b/server/module_test.go
@@ -1,13 +1,20 @@
 package server
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/petabytecl/gaz"
 	"github.com/petabytecl/gaz/di"
-	"github.com/petabytecl/gaz/server/grpc"
+	hello "github.com/petabytecl/gaz/examples/vanguard/proto"
+	servergrpc "github.com/petabytecl/gaz/server/grpc"
 	"github.com/petabytecl/gaz/server/vanguard"
 )
 
@@ -26,7 +33,7 @@ func TestNewModule(t *testing.T) {
 		c := app.Container()
 
 		// Verify servers were registered.
-		require.True(t, di.Has[*grpc.Server](c))
+		require.True(t, di.Has[*servergrpc.Server](c))
 		require.True(t, di.Has[*vanguard.Server](c))
 	})
 
@@ -43,7 +50,7 @@ func TestNewModule(t *testing.T) {
 
 		c := app.Container()
 
-		cfg, err := di.Resolve[grpc.Config](c)
+		cfg, err := di.Resolve[servergrpc.Config](c)
 		require.NoError(t, err)
 		require.True(t, cfg.SkipListener, "gRPC SkipListener must be true when using server module")
 	})
@@ -53,4 +60,89 @@ func TestNewModule(t *testing.T) {
 		module := NewModule()
 		require.Equal(t, "server", module.Name())
 	})
+}
+
+func TestNewModule_BridgesGRPCServicesThroughVanguard(t *testing.T) {
+	app := gaz.New()
+	app.Use(NewModule())
+
+	cfg := vanguard.DefaultConfig()
+	cfg.Port = getFreePort(t)
+	cfg.HealthEnabled = false
+	cfg.Reflection = false
+	cfg.DevMode = true
+	require.NoError(t, gaz.For[vanguard.Config](app.Container()).Replace().Instance(cfg))
+
+	require.NoError(t, gaz.For[*bridgeGreeterService](app.Container()).Instance(&bridgeGreeterService{}))
+
+	require.NoError(t, app.Build())
+	require.NoError(t, app.Start(context.Background()))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, app.Stop(ctx))
+	})
+
+	waitForPort(t, cfg.Port)
+
+	conn, err := googlegrpc.NewClient(
+		fmt.Sprintf("localhost:%d", cfg.Port),
+		googlegrpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	client := hello.NewGreeterClient(conn)
+	var reply *hello.HelloReply
+	var callErr error
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		reply, callErr = client.SayHello(ctx, &hello.HelloRequest{Name: "Bridge"})
+		return callErr == nil && reply.GetMessage() == "Hello from gRPC, Bridge!"
+	}, 2*time.Second, 20*time.Millisecond, "last gRPC error: %v", callErr)
+}
+
+type bridgeGreeterService struct {
+	hello.UnimplementedGreeterServer
+}
+
+func (s *bridgeGreeterService) SayHello(
+	_ context.Context,
+	req *hello.HelloRequest,
+) (*hello.HelloReply, error) {
+	return &hello.HelloReply{Message: fmt.Sprintf("Hello from gRPC, %s!", req.GetName())}, nil
+}
+
+func (s *bridgeGreeterService) RegisterService(registrar googlegrpc.ServiceRegistrar) {
+	hello.RegisterGreeterServer(registrar, s)
+}
+
+func getFreePort(t *testing.T) int {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, lis.Close())
+	}()
+
+	return lis.Addr().(*net.TCPAddr).Port
+}
+
+func waitForPort(t *testing.T, port int) {
+	t.Helper()
+
+	addr := fmt.Sprintf("localhost:%d", port)
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
 }

--- a/server/vanguard/module.go
+++ b/server/vanguard/module.go
@@ -183,7 +183,7 @@ func provideServer(c *gaz.Container) error {
 				return nil, fmt.Errorf("resolve vanguard config: %w", err)
 			}
 
-			// Resolve the gRPC server wrapper to get the raw *grpc.Server.
+			// Resolve the gRPC server wrapper; Vanguard reads the raw server during OnStart.
 			grpcSrv, err := gaz.Resolve[*grpcpkg.Server](c)
 			if err != nil {
 				return nil, fmt.Errorf("resolve grpc server: %w", err)

--- a/server/vanguard/module.go
+++ b/server/vanguard/module.go
@@ -189,7 +189,7 @@ func provideServer(c *gaz.Container) error {
 				return nil, fmt.Errorf("resolve grpc server: %w", err)
 			}
 
-			return NewServer(cfg, resolveLogger(c), c, grpcSrv.GRPCServer()), nil
+			return newServerWithGRPCSource(cfg, resolveLogger(c), c, grpcSrv), nil
 		}); err != nil {
 		return fmt.Errorf("register vanguard server: %w", err)
 	}

--- a/server/vanguard/server.go
+++ b/server/vanguard/server.go
@@ -26,11 +26,23 @@ type Server struct {
 	config             Config
 	httpServer         *http.Server
 	container          *di.Container
-	grpcServer         *grpc.Server
+	grpcServerSource   grpcServerSource
 	logger             *slog.Logger
 	healthManager      *health.Manager
 	healthConfig       *health.Config
 	userUnknownHandler http.Handler
+}
+
+type grpcServerSource interface {
+	GRPCServer() *grpc.Server
+}
+
+type staticGRPCServerSource struct {
+	server *grpc.Server
+}
+
+func (s staticGRPCServerSource) GRPCServer() *grpc.Server {
+	return s.server
 }
 
 // NewServer creates a new Vanguard server with the given configuration.
@@ -42,6 +54,15 @@ type Server struct {
 //   - container: DI container for service discovery
 //   - grpcServer: The raw *grpc.Server from the gRPC module (for vanguardgrpc bridge)
 func NewServer(cfg Config, logger *slog.Logger, container *di.Container, grpcServer *grpc.Server) *Server {
+	return newServerWithGRPCSource(cfg, logger, container, staticGRPCServerSource{server: grpcServer})
+}
+
+func newServerWithGRPCSource(
+	cfg Config,
+	logger *slog.Logger,
+	container *di.Container,
+	grpcSource grpcServerSource,
+) *Server {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -59,13 +80,20 @@ func NewServer(cfg Config, logger *slog.Logger, container *di.Container, grpcSer
 	}
 
 	return &Server{
-		config:        cfg,
-		container:     container,
-		grpcServer:    grpcServer,
-		logger:        logger,
-		healthManager: healthMgr,
-		healthConfig:  healthCfg,
+		config:           cfg,
+		container:        container,
+		grpcServerSource: grpcSource,
+		logger:           logger,
+		healthManager:    healthMgr,
+		healthConfig:     healthCfg,
 	}
+}
+
+func (s *Server) grpcServer() *grpc.Server {
+	if s.grpcServerSource == nil {
+		return nil
+	}
+	return s.grpcServerSource.GRPCServer()
 }
 
 // SetUnknownHandler sets a user-defined handler for non-RPC HTTP routes.
@@ -80,6 +108,8 @@ func (s *Server) SetUnknownHandler(h http.Handler) {
 // over h2c on the configured port.
 // Implements di.Starter.
 func (s *Server) OnStart(ctx context.Context) error {
+	grpcServer := s.grpcServer()
+
 	// 0. Collect Connect interceptors from DI.
 	connectInterceptors := connectpkg.CollectInterceptors(s.container, s.logger)
 	var handlerOpts []connect.HandlerOption
@@ -106,8 +136,8 @@ func (s *Server) OnStart(ctx context.Context) error {
 	}
 
 	// 3. Collect gRPC service names for reflection.
-	if s.grpcServer != nil {
-		for name := range s.grpcServer.GetServiceInfo() {
+	if grpcServer != nil {
+		for name := range grpcServer.GetServiceInfo() {
 			serviceNames = append(serviceNames, name)
 		}
 	}
@@ -140,7 +170,7 @@ func (s *Server) OnStart(ctx context.Context) error {
 	}
 
 	// 8. Build the transcoder.
-	handler, transcoderErr := s.buildTranscoder(transcoderOpts)
+	handler, transcoderErr := s.buildTranscoder(grpcServer, transcoderOpts)
 	if transcoderErr != nil {
 		return transcoderErr
 	}
@@ -182,7 +212,7 @@ func (s *Server) OnStart(ctx context.Context) error {
 		slog.Int("connect_interceptors", len(connectInterceptors)),
 		slog.Bool("reflection", s.config.Reflection),
 		slog.Bool("health", s.healthManager != nil),
-		slog.Bool("grpc_bridge", s.grpcServer != nil),
+		slog.Bool("grpc_bridge", grpcServer != nil),
 	)
 
 	// 11. Start serving in goroutine.
@@ -197,9 +227,12 @@ func (s *Server) OnStart(ctx context.Context) error {
 
 // buildTranscoder creates the Vanguard transcoder.
 // Uses vanguardgrpc if a gRPC server is available, otherwise uses plain vanguard transcoder.
-func (s *Server) buildTranscoder(opts []vanguard.TranscoderOption) (http.Handler, error) {
-	if s.grpcServer != nil {
-		transcoder, err := vanguardgrpc.NewTranscoder(s.grpcServer, opts...)
+func (s *Server) buildTranscoder(
+	grpcServer *grpc.Server,
+	opts []vanguard.TranscoderOption,
+) (http.Handler, error) {
+	if grpcServer != nil {
+		transcoder, err := vanguardgrpc.NewTranscoder(grpcServer, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("vanguard: build grpc transcoder: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Fix Vanguard server module wiring so it reads the raw gRPC server during `OnStart`, after the gRPC wrapper has initialized and registered services.
- Preserve the public `vanguard.NewServer(..., *grpc.Server)` constructor for direct callers.
- Add a regression proving a gRPC-only service is reachable through `server.NewModule()` on the Vanguard port.
- Add `docs/architecture-recommendations.md` as the current architecture backlog/resume point.

## Root Cause

The server module resolved `grpcSrv.GRPCServer()` while building the eager Vanguard provider. At that point the gRPC wrapper had not run `OnStart`, so the raw `*grpc.Server` was still nil. Vanguard then built a plain transcoder and logged `grpc_bridge=false` even though gRPC later started in skip-listener mode.

## Validation

- `git diff --check HEAD~1..HEAD`
- `make check`
- tracked-file `gofmt`/`goimports` check with `goimports` from `/tmp/gaz-tools`
- `make test`
- `make lint`
- `make cover` -> 91.1%
- `go test -race ./... -count=1`
