### PR TITLE
[codex] Deepen unified server bridge

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,3 +17,9 @@ Runtime participant registration is part of the lifecycle plan's policy surface.
 Configured module registration is the shared App-module pattern for wiring a module-owned configuration type into DI. The module owns its public adapter and flags, while the internal configured-module helper owns the repeated mechanics: start from defaults, overlay ProviderValues when available, apply the module's defaulting policy, and validate before exposing the config.
 
 This keeps package-level modules stable as public entry points while centralizing the registration rule that makes flags, config files, environment values, and DI providers agree on one typed config instance.
+
+### Unified server bridge
+
+The unified server bridge is the App-module pattern for installing the transport stack on one port. It owns the policy that makes the gRPC server register services without binding its own listener, then hands that gRPC adapter to Vanguard so Vanguard serves gRPC, Connect, gRPC-Web, REST transcoding, and non-RPC HTTP routes from the single public listener.
+
+Standalone transport modules remain valid on their own. The unified server bridge only owns the extra composition rule needed when callers choose the single-port default.

--- a/server/module.go
+++ b/server/module.go
@@ -1,38 +1,8 @@
 package server
 
 import (
-	"fmt"
-
 	"github.com/petabytecl/gaz"
-	"github.com/petabytecl/gaz/server/grpc"
-	"github.com/petabytecl/gaz/server/vanguard"
 )
-
-// forceSkipListener overrides the gRPC Config to set SkipListener=true.
-// This ensures gRPC registers services and interceptors but does not bind
-// its own listener — Vanguard handles all connections on a single port.
-func forceSkipListener(c *gaz.Container) error {
-	if err := gaz.For[grpc.Config](c).Replace().Provider(func(c *gaz.Container) (grpc.Config, error) {
-		cfg := grpc.DefaultConfig()
-
-		if pv, err := gaz.Resolve[*gaz.ProviderValues](c); err == nil {
-			if unmarshalErr := pv.UnmarshalKey(cfg.Namespace(), &cfg); unmarshalErr != nil {
-				_ = unmarshalErr
-			}
-		}
-
-		cfg.SkipListener = true
-
-		if err := cfg.Validate(); err != nil {
-			return grpc.Config{}, fmt.Errorf("grpc config validate: %w", err)
-		}
-
-		return cfg, nil
-	}); err != nil {
-		return fmt.Errorf("override grpc config: %w", err)
-	}
-	return nil
-}
 
 // NewModule creates a unified server module.
 // Returns a gaz.Module that bundles gRPC and Vanguard modules with gRPC
@@ -59,9 +29,7 @@ func forceSkipListener(c *gaz.Container) error {
 //	app := gaz.New()
 //	app.Use(server.NewModule())
 func NewModule() gaz.Module {
-	return gaz.NewModule("server").
-		Use(grpc.NewModule()).
-		Use(vanguard.NewModule()).
-		Provide(forceSkipListener).
+	return newUnifiedServerBridge().
+		configure(gaz.NewModule(unifiedServerBridgeModuleName)).
 		Build()
 }

--- a/server/module_test.go
+++ b/server/module_test.go
@@ -62,6 +62,33 @@ func TestNewModule(t *testing.T) {
 	})
 }
 
+func TestNewModule_ForcesGRPCServiceRegistrationOnly(t *testing.T) {
+	app := gaz.New()
+	app.Use(NewModule())
+
+	require.NoError(t, app.MergeConfigMap(map[string]any{
+		"grpc": map[string]any{
+			"port":              43210,
+			"reflection":        true,
+			"health_enabled":    false,
+			"max_recv_msg_size": 1024,
+			"max_send_msg_size": 2048,
+			"skip_listener":     false,
+		},
+	}))
+
+	require.NoError(t, app.Build())
+
+	cfg, err := di.Resolve[servergrpc.Config](app.Container())
+	require.NoError(t, err)
+	require.Equal(t, 43210, cfg.Port)
+	require.True(t, cfg.Reflection)
+	require.False(t, cfg.HealthEnabled)
+	require.Equal(t, 1024, cfg.MaxRecvMsgSize)
+	require.Equal(t, 2048, cfg.MaxSendMsgSize)
+	require.True(t, cfg.SkipListener)
+}
+
 func TestNewModule_BridgesGRPCServicesThroughVanguard(t *testing.T) {
 	app := gaz.New()
 	app.Use(NewModule())

--- a/server/unified_server_bridge.go
+++ b/server/unified_server_bridge.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/server/grpc"
+	"github.com/petabytecl/gaz/server/vanguard"
+)
+
+const unifiedServerBridgeModuleName = "server"
+
+// unifiedServerBridge owns the single-port transport composition rule.
+//
+// Standalone gRPC and Vanguard modules remain usable on their own. The bridge
+// adds only the policy needed when callers choose server.NewModule(): gRPC
+// registers services without binding a listener, and Vanguard owns the public
+// listener for all protocols.
+type unifiedServerBridge struct {
+	grpcModule     gaz.Module
+	vanguardModule gaz.Module
+}
+
+func newUnifiedServerBridge() unifiedServerBridge {
+	return unifiedServerBridge{
+		grpcModule:     grpc.NewModule(),
+		vanguardModule: vanguard.NewModule(),
+	}
+}
+
+func (b unifiedServerBridge) configure(builder *gaz.ModuleBuilder) *gaz.ModuleBuilder {
+	return builder.
+		Use(b.grpcModule).
+		Use(b.vanguardModule).
+		Provide(forceGRPCServiceRegistrationOnly)
+}
+
+func forceGRPCServiceRegistrationOnly(c *gaz.Container) error {
+	if err := gaz.For[grpc.Config](c).Replace().Provider(grpcBridgeConfig); err != nil {
+		return fmt.Errorf("override grpc config: %w", err)
+	}
+	return nil
+}
+
+func grpcBridgeConfig(c *gaz.Container) (grpc.Config, error) {
+	cfg := grpc.DefaultConfig()
+	overlayGRPCProviderValues(c, &cfg)
+
+	cfg.SkipListener = true
+
+	if err := cfg.Validate(); err != nil {
+		return grpc.Config{}, fmt.Errorf("grpc config validate: %w", err)
+	}
+	return cfg, nil
+}
+
+func overlayGRPCProviderValues(c *gaz.Container, cfg *grpc.Config) {
+	pv, err := gaz.Resolve[*gaz.ProviderValues](c)
+	if err != nil {
+		return
+	}
+	if unmarshalErr := pv.UnmarshalKey(cfg.Namespace(), cfg); unmarshalErr != nil {
+		return
+	}
+}

--- a/worker/supervisor_test.go
+++ b/worker/supervisor_test.go
@@ -15,14 +15,12 @@ import (
 
 // mockWorker is a test helper for simulating worker behavior.
 type mockWorker struct {
-	name         string
-	startCount   int32
-	stopCount    int32
-	started      chan struct{}
-	stopped      chan struct{}
-	stopCh       chan struct{}
-	panicOnStart bool
-	mu           sync.Mutex
+	name       string
+	startCount int32
+	stopCount  int32
+	started    chan struct{}
+	stopped    chan struct{}
+	mu         sync.Mutex
 }
 
 func newMockWorker(name string) *mockWorker {
@@ -30,15 +28,11 @@ func newMockWorker(name string) *mockWorker {
 		name:    name,
 		started: make(chan struct{}),
 		stopped: make(chan struct{}),
-		stopCh:  make(chan struct{}),
 	}
 }
 
 func (w *mockWorker) OnStart(ctx context.Context) error {
 	atomic.AddInt32(&w.startCount, 1)
-	if w.panicOnStart {
-		panic("intentional panic for testing")
-	}
 	close(w.started)
 	return nil
 }


### PR DESCRIPTION
## Summary

- move the server composition policy into a private unified server bridge module
- force the public server module into the single-port default by setting gRPC to service-registration-only mode
- add regression coverage that preserves provider-configured gRPC values while forcing `SkipListener`
- fold in the safe cleanup from PR #37 by removing unused `mockWorker` fields while keeping `panicWorker`, which is still used by supervisor tests

## PR #37

Fetched PR #37 and did not cherry-pick it as-is because it deletes `panicWorker` while `worker/supervisor_test.go` still uses that helper. This branch incorporates the valid cleanup from that PR and keeps the test suite compiling.

After this replacement PR is open, PR #37 can be closed as superseded.

## Test plan

- `git diff --check`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... -count=1`
- `make check`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go run golang.org/x/tools/cmd/goimports@latest -l server/module.go server/unified_server_bridge.go server/module_test.go worker/supervisor_test.go`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make lint`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make cover`
