### PR TITLE
[codex] Extract lifecycle session

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,12 @@ The lifecycle plan also owns runtime participant classification for App-managed 
 
 Runtime participant registration is part of the lifecycle plan's policy surface. A classified worker or cron job must resolve and register successfully during `App.Build()`; otherwise the application fails to build with an actionable error instead of silently dropping the participant.
 
+### Lifecycle session
+
+A lifecycle session is one run of a built App. It owns the runtime orchestration policy around entering the running state, waiting for shutdown triggers, invoking lifecycle execution, enforcing process-level shutdown deadlines, and leaving the running state.
+
+The lifecycle session is distinct from the lifecycle plan and lifecycle execution. The lifecycle plan decides what should run; lifecycle execution starts and stops planned participants; the lifecycle session coordinates when execution begins and how shutdown is triggered and finalized.
+
 ### Configured module registration
 
 Configured module registration is the shared App-module pattern for wiring a module-owned configuration type into DI. The module owns its public adapter and flags, while the internal configured-module helper owns the repeated mechanics: start from defaults, overlay ProviderValues when available, apply the module's defaulting policy, and validate before exposing the config.

--- a/app.go
+++ b/app.go
@@ -130,6 +130,7 @@ type App struct {
 	// cachedLifecyclePlan stores the structural runtime plan computed during Build.
 	// Start resolves lifecycle services into it before execution; Stop reuses it.
 	cachedLifecyclePlan *lifecyclePlan
+	session             *lifecycleSession
 
 	mu      sync.Mutex
 	running bool

--- a/app_run.go
+++ b/app_run.go
@@ -2,134 +2,26 @@ package gaz
 
 import (
 	"context"
-	"errors"
 	"os"
-	"os/signal"
-	"syscall"
 )
 
 // Run executes the application lifecycle.
 // It builds the container, starts services in order, and waits for a signal or stop call.
 func (a *App) Run(ctx context.Context) error {
-	if err := a.Build(); err != nil {
-		return err
-	}
-
-	a.mu.Lock()
-	if a.running {
-		a.mu.Unlock()
-		return errors.New("app is already running")
-	}
-	a.stopCh = make(chan struct{})
-	a.running = true
-	a.mu.Unlock()
-
-	defer func() {
-		a.mu.Lock()
-		a.running = false
-		a.mu.Unlock()
-	}()
-
-	if err := a.startServices(ctx); err != nil {
-		return err
-	}
-
-	return a.waitForShutdownSignal(ctx)
+	return a.lifecycleSession().Run(ctx)
 }
 
-// startServices starts services layer by layer in parallel, and then starts
-// the worker manager. On failure at any stage it rolls back by stopping
-// already-started services.
-//
-// The lifecycle plan is already resolved during Build(), so plan data
-// (startupOrder, shutdownOrder, services) is immutable here.
-func (a *App) startServices(ctx context.Context) error {
-	plan, err := a.lifecyclePlan()
-	if err != nil {
-		return err
-	}
-
-	return a.lifecycleExecutor(plan).Start(ctx, a.Stop)
+// Start initiates the application lifecycle.
+// This is called automatically by WithCobra() or can be called manually.
+func (a *App) Start(ctx context.Context) error {
+	return a.lifecycleSession().Start(ctx)
 }
 
-// waitForShutdownSignal blocks until a shutdown trigger (signal, context cancel, or Stop call).
-// Returns the result of graceful shutdown.
-func (a *App) waitForShutdownSignal(ctx context.Context) error {
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
-
-	select {
-	case <-ctx.Done():
-		// Context cancelled, treat like SIGTERM (graceful, no double-signal)
-		a.Logger.InfoContext(ctx, "Shutting down gracefully...", "reason", "context cancelled")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), a.opts.ShutdownTimeout)
-		defer cancel()
-		return a.Stop(shutdownCtx)
-
-	case sig := <-sigCh:
-		return a.handleSignalShutdown(ctx, sig, sigCh)
-
-	case <-a.stopCh:
-		// Stopped externally (Stop() called)
-		return nil
-	}
-}
-
-// handleSignalShutdown handles graceful shutdown triggered by a signal.
-// For SIGINT, it spawns a force-exit watcher that exits immediately on second SIGINT.
-// For SIGTERM, it performs graceful shutdown without double-signal behavior.
-//
-// The watcher goroutine is synchronized so it exits before this function returns,
-// ensuring signal.Stop(sigCh) in the caller does not race with the watcher.
+// handleSignalShutdown is kept as a private compatibility wrapper for tests.
 func (a *App) handleSignalShutdown(
 	ctx context.Context,
 	sig os.Signal,
 	sigCh <-chan os.Signal,
 ) error {
-	if sig == os.Interrupt {
-		a.Logger.InfoContext(ctx, "Shutting down gracefully...", "hint", "Ctrl+C again to force")
-	} else {
-		a.Logger.InfoContext(ctx, "Shutting down gracefully...", "signal", sig.String())
-	}
-
-	// Create shutdown context
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), a.opts.ShutdownTimeout)
-	defer cancel()
-
-	shutdownErr := make(chan error, 1)
-	shutdownDone := make(chan struct{})
-
-	// Start graceful shutdown in goroutine so we can continue listening for signals
-	go func() {
-		defer close(shutdownDone)
-		shutdownErr <- a.Stop(shutdownCtx)
-	}()
-
-	// If SIGINT, spawn force-exit watcher goroutine.
-	// watcherDone is closed when the watcher exits, so we can wait for it
-	// before returning (ensuring signal.Stop runs after the watcher).
-	watcherDone := make(chan struct{})
-	if sig == os.Interrupt {
-		go func() {
-			defer close(watcherDone)
-			select {
-			case <-sigCh:
-				// Second SIGINT received - force exit immediately
-				a.Logger.ErrorContext(ctx, "Received second interrupt, forcing exit")
-				callExitFunc(1)
-			case <-shutdownDone:
-				// Normal completion, watcher exits
-			}
-		}()
-	} else {
-		close(watcherDone) // No watcher for non-SIGINT signals
-	}
-
-	// Wait for shutdown to complete
-	err := <-shutdownErr
-	// Ensure watcher goroutine exits before returning, so that
-	// defer signal.Stop(sigCh) in the caller runs after the watcher.
-	<-watcherDone
-	return err
+	return a.lifecycleSession().handleSignalShutdown(ctx, sig, sigCh)
 }

--- a/app_shutdown.go
+++ b/app_shutdown.go
@@ -2,10 +2,6 @@ package gaz
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"os"
-	"time"
 )
 
 // Stop initiates graceful shutdown of the application.
@@ -13,90 +9,5 @@ import (
 // Safe to call even if Run() was not used (e.g., Cobra integration).
 // Stop is idempotent - calling it multiple times returns the same result.
 func (a *App) Stop(ctx context.Context) error {
-	a.stopOnce.Do(func() {
-		a.stopErr = a.doStop(ctx)
-	})
-	return a.stopErr
-}
-
-// doStop performs the actual shutdown. Called only once via stopOnce.
-func (a *App) doStop(ctx context.Context) error {
-	a.mu.Lock()
-	wasRunning := a.running
-	wasBuilt := a.built
-	a.mu.Unlock()
-
-	// If app was never built, there's nothing to stop
-	if !wasBuilt {
-		return nil
-	}
-
-	// Cancel the cron scheduler context
-	if a.cronCancel != nil {
-		a.cronCancel()
-	}
-
-	// Start global timeout force-exit goroutine
-	done := make(chan struct{})
-	timer := time.NewTimer(a.opts.ShutdownTimeout)
-	go func() {
-		select {
-		case <-done:
-			timer.Stop()
-			return
-		case <-timer.C:
-			// Re-check: shutdown may have finished between timer fire and this point
-			select {
-			case <-done:
-				return // Clean exit won the race
-			default:
-				msg := fmt.Sprintf(
-					"shutdown: global timeout %s exceeded, forcing exit",
-					a.opts.ShutdownTimeout,
-				)
-				a.getLogger().Error(msg)
-				_, _ = fmt.Fprintln(os.Stderr, msg)
-				callExitFunc(1)
-			}
-		}
-	}()
-
-	plan, err := a.lifecyclePlan()
-	if err != nil {
-		close(done)
-		// Should not happen if Build passed, unless graph changed (impossible after Build)
-		return err
-	}
-
-	var errs []error
-	if stopErr := a.lifecycleExecutor(plan).Stop(ctx); stopErr != nil {
-		errs = append(errs, stopErr)
-	}
-
-	// Close logger file handle (if any) — after all services stopped, before exit
-	if a.logCloser != nil {
-		if closeErr := a.logCloser.Close(); closeErr != nil {
-			errs = append(errs, fmt.Errorf("closing logger: %w", closeErr))
-		}
-	}
-
-	// Cancel the force-exit goroutine
-	close(done)
-
-	// Signal Run to exit (only if Run() was used)
-	if wasRunning {
-		a.mu.Lock()
-		select {
-		case <-a.stopCh:
-			// Already closed
-		default:
-			close(a.stopCh)
-		}
-		a.mu.Unlock()
-	}
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
+	return a.lifecycleSession().Stop(ctx)
 }

--- a/cobra.go
+++ b/cobra.go
@@ -2,8 +2,6 @@ package gaz
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -66,126 +64,15 @@ func WithCobra(cmd *cobra.Command) Option {
 		originalPreRunE := cmd.PersistentPreRunE
 		originalPostRunE := cmd.PersistentPostRunE
 
-		cmd.PersistentPreRunE = a.makePreRunE(originalPreRunE)
-		cmd.PersistentPostRunE = a.makePostRunE(originalPostRunE)
+		session := a.lifecycleSession()
+		cmd.PersistentPreRunE = session.makePreRunE(originalPreRunE)
+		cmd.PersistentPostRunE = session.makePostRunE(originalPostRunE)
 
 		// Inject default RunE if no Run/RunE is defined
 		if cmd.Run == nil && cmd.RunE == nil {
 			cmd.RunE = func(c *cobra.Command, _ []string) error {
-				return a.waitForShutdownSignal(c.Context())
+				return session.waitForShutdownSignal(c.Context())
 			}
 		}
 	}
-}
-
-// makePreRunE creates the PersistentPreRunE hook that bootstraps the app.
-func (a *App) makePreRunE(original func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
-	return func(c *cobra.Command, args []string) error {
-		if original != nil {
-			if err := original(c, args); err != nil {
-				return err
-			}
-		}
-
-		ctx := c.Context()
-		if ctx == nil {
-			ctx = context.Background()
-		}
-
-		if err := a.bootstrap(ctx, c, args); err != nil {
-			return err
-		}
-
-		c.SetContext(context.WithValue(ctx, contextKey{}, a))
-		return nil
-	}
-}
-
-// makePostRunE creates the PersistentPostRunE hook that stops the app.
-func (a *App) makePostRunE(original func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
-	return func(c *cobra.Command, args []string) error {
-		stopCtx, cancel := context.WithTimeout(context.Background(), a.opts.ShutdownTimeout)
-		defer cancel()
-
-		stopErr := a.Stop(stopCtx)
-
-		a.mu.Lock()
-		a.running = false
-		a.mu.Unlock()
-
-		if original != nil {
-			if err := original(c, args); err != nil {
-				return errors.Join(stopErr, err)
-			}
-		}
-
-		return stopErr
-	}
-}
-
-func (a *App) bootstrap(ctx context.Context, cmd *cobra.Command, args []string) error {
-	// Register CommandArgs
-	_ = For[*CommandArgs](a.container).Instance(&CommandArgs{
-		Command: cmd,
-		Args:    args,
-	})
-
-	// Bind flags if ConfigManager is available
-	if a.configMgr != nil {
-		if err := a.configMgr.BindFlags(cmd.Flags()); err != nil {
-			return fmt.Errorf("failed to bind flags: %w", err)
-		}
-	}
-
-	// Initialize run state similar to App.Run
-	a.mu.Lock()
-	if a.running {
-		a.mu.Unlock()
-		return errors.New("app is already running")
-	}
-	a.stopCh = make(chan struct{})
-	a.running = true
-	a.mu.Unlock()
-
-	// Ensure we clean up if start fails
-	success := false
-	defer func() {
-		if !success {
-			a.mu.Lock()
-			a.running = false
-			a.mu.Unlock()
-		}
-	}()
-
-	// Build the app (validates registrations)
-	if err := a.Build(); err != nil {
-		return fmt.Errorf("app build failed: %w", err)
-	}
-
-	// Start lifecycle hooks
-	if err := a.Start(ctx); err != nil {
-		return fmt.Errorf("app start failed: %w", err)
-	}
-
-	success = true
-	return nil
-}
-
-// Start initiates the application lifecycle.
-// This is called automatically by WithCobra() or can be called manually.
-// It delegates to startServices() which provides worker filtering, parallel layer
-// startup, panic recovery, rollback on failure, and worker manager start.
-func (a *App) Start(ctx context.Context) error {
-	// Ensure Build() was called first
-	a.mu.Lock()
-	if !a.built {
-		a.mu.Unlock()
-		if err := a.Build(); err != nil {
-			return err
-		}
-		a.mu.Lock()
-	}
-	a.mu.Unlock()
-
-	return a.startServices(ctx)
 }

--- a/lifecycle_session.go
+++ b/lifecycle_session.go
@@ -1,0 +1,341 @@
+package gaz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// lifecycleSession owns one App runtime session. App remains the public facade;
+// this module owns running-state, shutdown triggers, and one-shot stop policy.
+type lifecycleSession struct {
+	app *App
+}
+
+func newLifecycleSession(app *App) *lifecycleSession {
+	return &lifecycleSession{app: app}
+}
+
+func (a *App) lifecycleSession() *lifecycleSession {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.session == nil {
+		a.session = newLifecycleSession(a)
+	}
+	return a.session
+}
+
+func (s *lifecycleSession) Run(ctx context.Context) error {
+	if err := s.app.Build(); err != nil {
+		return err
+	}
+
+	if err := s.enterRunning(); err != nil {
+		return err
+	}
+	defer s.leaveRunning()
+
+	if err := s.startServices(ctx); err != nil {
+		return err
+	}
+
+	return s.waitForShutdownSignal(ctx)
+}
+
+func (s *lifecycleSession) Start(ctx context.Context) error {
+	a := s.app
+
+	a.mu.Lock()
+	if !a.built {
+		a.mu.Unlock()
+		if err := a.Build(); err != nil {
+			return err
+		}
+		a.mu.Lock()
+	}
+	a.mu.Unlock()
+
+	return s.startServices(ctx)
+}
+
+func (s *lifecycleSession) Stop(ctx context.Context) error {
+	s.app.stopOnce.Do(func() {
+		s.app.stopErr = s.doStop(ctx)
+	})
+	return s.app.stopErr
+}
+
+func (s *lifecycleSession) startServices(ctx context.Context) error {
+	plan, err := s.app.lifecyclePlan()
+	if err != nil {
+		return err
+	}
+
+	return s.app.lifecycleExecutor(plan).Start(ctx, s.Stop)
+}
+
+func (s *lifecycleSession) makePreRunE(
+	original func(*cobra.Command, []string) error,
+) func(*cobra.Command, []string) error {
+	return func(c *cobra.Command, args []string) error {
+		if original != nil {
+			if err := original(c, args); err != nil {
+				return err
+			}
+		}
+
+		ctx := c.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		if err := s.bootstrap(ctx, c, args); err != nil {
+			return err
+		}
+
+		c.SetContext(context.WithValue(ctx, contextKey{}, s.app))
+		return nil
+	}
+}
+
+func (s *lifecycleSession) makePostRunE(
+	original func(*cobra.Command, []string) error,
+) func(*cobra.Command, []string) error {
+	return func(c *cobra.Command, args []string) error {
+		stopCtx, cancel := context.WithTimeout(context.Background(), s.app.opts.ShutdownTimeout)
+		defer cancel()
+
+		stopErr := s.Stop(stopCtx)
+		s.leaveRunning()
+
+		if original != nil {
+			if err := original(c, args); err != nil {
+				return errors.Join(stopErr, err)
+			}
+		}
+
+		return stopErr
+	}
+}
+
+func (s *lifecycleSession) bootstrap(ctx context.Context, cmd *cobra.Command, args []string) error {
+	_ = For[*CommandArgs](s.app.container).Instance(&CommandArgs{
+		Command: cmd,
+		Args:    args,
+	})
+
+	if s.app.configMgr != nil {
+		if err := s.app.configMgr.BindFlags(cmd.Flags()); err != nil {
+			return fmt.Errorf("failed to bind flags: %w", err)
+		}
+	}
+
+	if err := s.enterRunning(); err != nil {
+		return err
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			s.leaveRunning()
+		}
+	}()
+
+	if err := s.app.Build(); err != nil {
+		return fmt.Errorf("app build failed: %w", err)
+	}
+
+	if err := s.Start(ctx); err != nil {
+		return fmt.Errorf("app start failed: %w", err)
+	}
+
+	success = true
+	return nil
+}
+
+func (s *lifecycleSession) enterRunning() error {
+	s.app.mu.Lock()
+	defer s.app.mu.Unlock()
+
+	if s.app.running {
+		return errors.New("app is already running")
+	}
+	s.app.stopCh = make(chan struct{})
+	s.app.running = true
+	return nil
+}
+
+func (s *lifecycleSession) leaveRunning() {
+	s.app.mu.Lock()
+	s.app.running = false
+	s.app.mu.Unlock()
+}
+
+func (s *lifecycleSession) waitForShutdownSignal(ctx context.Context) error {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	select {
+	case <-ctx.Done():
+		s.app.Logger.InfoContext(ctx, "Shutting down gracefully...", "reason", "context cancelled")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.app.opts.ShutdownTimeout)
+		defer cancel()
+		return s.Stop(shutdownCtx)
+
+	case sig := <-sigCh:
+		return s.handleSignalShutdown(ctx, sig, sigCh)
+
+	case <-s.app.stopCh:
+		return nil
+	}
+}
+
+func (s *lifecycleSession) handleSignalShutdown(
+	ctx context.Context,
+	sig os.Signal,
+	sigCh <-chan os.Signal,
+) error {
+	if sig == os.Interrupt {
+		s.app.Logger.InfoContext(ctx, "Shutting down gracefully...", "hint", "Ctrl+C again to force")
+	} else {
+		s.app.Logger.InfoContext(ctx, "Shutting down gracefully...", "signal", sig.String())
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), s.app.opts.ShutdownTimeout)
+	defer cancel()
+
+	shutdownErr := make(chan error, 1)
+	shutdownDone := make(chan struct{})
+
+	go func() {
+		defer close(shutdownDone)
+		shutdownErr <- s.Stop(shutdownCtx)
+	}()
+
+	watcherDone := make(chan struct{})
+	if sig == os.Interrupt {
+		go func() {
+			defer close(watcherDone)
+			select {
+			case <-sigCh:
+				s.app.Logger.ErrorContext(ctx, "Received second interrupt, forcing exit")
+				callExitFunc(1)
+			case <-shutdownDone:
+			}
+		}()
+	} else {
+		close(watcherDone)
+	}
+
+	err := <-shutdownErr
+	<-watcherDone
+	return err
+}
+
+func (s *lifecycleSession) doStop(ctx context.Context) error {
+	wasRunning, wasBuilt := s.stopState()
+	if !wasBuilt {
+		return nil
+	}
+
+	if s.app.cronCancel != nil {
+		s.app.cronCancel()
+	}
+
+	done := s.startForceExitTimer()
+
+	errs, err := s.stopPlannedLifecycle(ctx)
+	if err != nil {
+		close(done)
+		return err
+	}
+
+	if closeErr := s.closeLogger(); closeErr != nil {
+		errs = append(errs, closeErr)
+	}
+
+	close(done)
+	s.signalRunStopped(wasRunning)
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func (s *lifecycleSession) stopState() (bool, bool) {
+	s.app.mu.Lock()
+	wasRunning := s.app.running
+	wasBuilt := s.app.built
+	s.app.mu.Unlock()
+	return wasRunning, wasBuilt
+}
+
+func (s *lifecycleSession) startForceExitTimer() chan struct{} {
+	done := make(chan struct{})
+	timer := time.NewTimer(s.app.opts.ShutdownTimeout)
+	go func() {
+		select {
+		case <-done:
+			timer.Stop()
+			return
+		case <-timer.C:
+			select {
+			case <-done:
+				return
+			default:
+				msg := fmt.Sprintf(
+					"shutdown: global timeout %s exceeded, forcing exit",
+					s.app.opts.ShutdownTimeout,
+				)
+				s.app.getLogger().Error(msg)
+				_, _ = fmt.Fprintln(os.Stderr, msg)
+				callExitFunc(1)
+			}
+		}
+	}()
+	return done
+}
+
+func (s *lifecycleSession) stopPlannedLifecycle(ctx context.Context) ([]error, error) {
+	plan, err := s.app.lifecyclePlan()
+	if err != nil {
+		return nil, err
+	}
+
+	var errs []error
+	if stopErr := s.app.lifecycleExecutor(plan).Stop(ctx); stopErr != nil {
+		errs = append(errs, stopErr)
+	}
+
+	return errs, nil
+}
+
+func (s *lifecycleSession) closeLogger() error {
+	if s.app.logCloser != nil {
+		if closeErr := s.app.logCloser.Close(); closeErr != nil {
+			return fmt.Errorf("closing logger: %w", closeErr)
+		}
+	}
+	return nil
+}
+
+func (s *lifecycleSession) signalRunStopped(wasRunning bool) {
+	if wasRunning {
+		s.app.mu.Lock()
+		select {
+		case <-s.app.stopCh:
+		default:
+			close(s.app.stopCh)
+		}
+		s.app.mu.Unlock()
+	}
+}


### PR DESCRIPTION
## Summary
- add a private lifecycleSession module for App runtime-session orchestration
- keep App.Run, App.Start, and App.Stop as thin public facade methods
- move Cobra bootstrap, shutdown waiting, signal handling, global force-exit timing, logger close, and stop idempotency behind the session
- document lifecycle session in CONTEXT.md

## Notes
This is intended as a behavior-preserving first slice. App still stores the existing running/stop/idempotency fields so tests and current internal contracts remain stable.

## Test plan
- git diff --check
- make check
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go run golang.org/x/tools/cmd/goimports@latest -l app.go app_run.go app_shutdown.go cobra.go lifecycle_session.go
- GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make lint
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... -count=1
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make cover
