### PR TITLE
[codex] Formalize module identity

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,3 +29,9 @@ This keeps package-level modules stable as public entry points while centralizin
 The unified server bridge is the App-module pattern for installing the transport stack on one port. It owns the policy that makes the gRPC server register services without binding its own listener, then hands that gRPC adapter to Vanguard so Vanguard serves gRPC, Connect, gRPC-Web, REST transcoding, and non-RPC HTTP routes from the single public listener.
 
 Standalone transport modules remain valid on their own. The unified server bridge only owns the extra composition rule needed when callers choose the single-port default.
+
+### Module identity
+
+Module identity is the stable name a module uses for duplicate detection, auto-registration skip logic, and diagnostics. The owning package exposes the identity when callers or sibling adapter packages need to reason about whether the feature module is installed.
+
+A flags adapter may have its own module identity when applying the adapter is not the same thing as installing the feature infrastructure. That distinction must be explicit instead of encoded as an ad hoc string in the adapter.

--- a/config/module.go
+++ b/config/module.go
@@ -33,7 +33,7 @@ func NewModule(opts ...ModuleOption) di.Module {
 		opt(cfg)
 	}
 
-	return di.NewModuleFunc("config", func(c *di.Container) error {
+	return di.NewModuleFunc(ModuleName, func(c *di.Container) error {
 		// Config infrastructure is set up in gaz.New() and
 		// configured via WithConfig(). This module provides
 		// a placeholder for future extensions like:

--- a/config/module/module.go
+++ b/config/module/module.go
@@ -93,7 +93,7 @@ func (c *Config) GetSearchPaths(appName string) []string {
 func New() gaz.Module {
 	defaultCfg := DefaultConfig()
 
-	return gaz.NewModule("config-flags").
+	return gaz.NewModule(config.FlagsModuleName).
 		Flags(defaultCfg.Flags).
 		Provide(configuredmodule.ProvideDefaulted[Config, *Config](
 			&defaultCfg,

--- a/config/module/module_test.go
+++ b/config/module/module_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/config"
 	configmod "github.com/petabytecl/gaz/config/module"
 )
 
@@ -36,6 +37,10 @@ func (s *ConfigModuleSuite) TestDefaultConfig() {
 func (s *ConfigModuleSuite) TestConfigNamespace() {
 	cfg := configmod.DefaultConfig()
 	s.Equal("config", cfg.Namespace())
+}
+
+func (s *ConfigModuleSuite) TestModuleName() {
+	s.Equal(config.FlagsModuleName, configmod.New().Name())
 }
 
 func (s *ConfigModuleSuite) TestConfigSetDefaults() {

--- a/config/module_identity.go
+++ b/config/module_identity.go
@@ -1,0 +1,10 @@
+package config
+
+const (
+	// ModuleName is the canonical identity for configuration infrastructure.
+	ModuleName = "config"
+
+	// FlagsModuleName is the identity for the Cobra flags adapter that wires
+	// configuration flags into gaz.App.
+	FlagsModuleName = "config-flags"
+)

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -21,7 +21,7 @@ func TestNewModule(t *testing.T) {
 	t.Run("returns valid di.Module", func(t *testing.T) {
 		mod := NewModule()
 		require.NotNil(t, mod)
-		require.Equal(t, "config", mod.Name())
+		require.Equal(t, ModuleName, mod.Name())
 	})
 
 	t.Run("accepts options", func(t *testing.T) {

--- a/cron/module/module.go
+++ b/cron/module/module.go
@@ -19,7 +19,7 @@ import (
 // The module provides:
 //   - *cron.Scheduler for scheduling cron jobs
 func New() gaz.Module {
-	return gaz.NewModule("cron").
+	return gaz.NewModule(cron.ModuleName).
 		Provide(cron.Module).
 		Build()
 }

--- a/cron/module/module_test.go
+++ b/cron/module/module_test.go
@@ -13,6 +13,7 @@ func TestNew(t *testing.T) {
 	t.Run("creates valid module", func(t *testing.T) {
 		mod := New()
 		require.NotNil(t, mod)
+		require.Equal(t, cron.ModuleName, mod.Name())
 	})
 
 	t.Run("integrates with gaz.App", func(t *testing.T) {

--- a/cron/module_identity.go
+++ b/cron/module_identity.go
@@ -1,0 +1,4 @@
+package cron
+
+// ModuleName is the canonical identity for the cron module.
+const ModuleName = "cron"

--- a/docs/architecture-recommendations.md
+++ b/docs/architecture-recommendations.md
@@ -1,6 +1,6 @@
 # Architecture Recommendations Backlog
 
-Last updated: 2026-05-22
+Last updated: 2026-05-24
 
 This document captures the remaining architecture recommendations for `gaz` after the merged lifecycle/config refactor series. It is meant as a resume point for future Codex sessions.
 
@@ -8,6 +8,7 @@ Use the vocabulary in `CONTEXT.md`:
 
 - A **lifecycle plan** owns runtime policy: which services participate, which runtime participants are handed to App-managed managers, and what startup/shutdown order is used.
 - **Configured module registration** owns the shared rule for module-owned config values.
+- **Module identity** owns the stable name used for duplicate detection, auto-registration skip logic, and diagnostics.
 - Architecture recommendations should deepen modules: put policy behind smaller interfaces, improve locality, and keep behavior testable through the public or private module seam.
 
 ## Current Baseline
@@ -19,6 +20,12 @@ Already completed:
 - Configured module registration was centralized under `internal/configuredmodule`.
 - Runtime participant classification moved into the lifecycle plan.
 - Worker and cron participant registration now fails `App.Build()` when a participant cannot resolve, resolves to the wrong type, or cannot register.
+- Health auto-registration moved behind a dedicated private module.
+- The App build sequence is named and testable through private build phases.
+- Config flag interpretation moved behind a private config flag policy.
+- Runtime subsystem construction moved behind a private runtime-subsystems module.
+- Lifecycle session orchestration moved behind a private lifecycle session.
+- Feature module identities are exposed by the owning packages; config keeps a deliberately separate `config-flags` adapter identity.
 
 Quality gate expectation for future PRs:
 
@@ -33,6 +40,8 @@ Quality gate expectation for future PRs:
 ## Priority 1: Extract Health Auto-Registration Policy
 
 Recommendation strength: Strong
+
+Status: Completed.
 
 Files:
 
@@ -77,6 +86,8 @@ This is the smallest remaining high-leverage slice. It removes feature-specific 
 ## Priority 2: Deepen the App Build Sequence
 
 Recommendation strength: Strong, after Priority 1
+
+Status: Completed.
 
 Files:
 
@@ -123,6 +134,8 @@ Suggested tests:
 
 Recommendation strength: Worth exploring
 
+Status: Completed.
+
 Files:
 
 - `app_config.go`
@@ -155,6 +168,8 @@ Suggested tests:
 ## Priority 4: Deepen Runtime Subsystem Initialization
 
 Recommendation strength: Worth exploring
+
+Status: Completed.
 
 Files:
 
@@ -197,6 +212,8 @@ Suggested tests:
 
 Recommendation strength: Worth exploring
 
+Status: Completed.
+
 Files:
 
 - `app_run.go`
@@ -231,6 +248,8 @@ Suggested tests:
 
 Recommendation strength: Worth exploring
 
+Status: Completed.
+
 Files:
 
 - `app_use.go`
@@ -241,11 +260,11 @@ Files:
 
 Problem:
 
-Feature modules do not currently have a clear naming convention for "feature is installed" versus "flags adapter is installed". Health exposes this most clearly: `health/module.New()` uses the module name `health-flags`, while App auto-registration checks `health`.
+Feature modules did not have a clear naming convention for "feature is installed" versus "flags adapter is installed". Health originally exposed this most clearly: `health/module.New()` used the module name `health-flags`, while App auto-registration checked `health`.
 
 Solution:
 
-Define a convention for module identity. A feature module should expose one stable identity for duplicate detection and auto-registration skip logic. If flags are a separate adapter, encode that deliberately instead of relying on ad hoc string checks.
+Define a convention for module identity. A feature module exposes one stable identity for duplicate detection and auto-registration skip logic. If flags are a separate adapter, encode that deliberately instead of relying on ad hoc string checks.
 
 Benefits:
 
@@ -262,6 +281,8 @@ Suggested tests:
 ## Priority 7: Decide Whether `config.NewModule()` Should Exist
 
 Recommendation strength: Speculative
+
+Status: Next.
 
 Files:
 
@@ -295,11 +316,11 @@ Suggested tests:
 ## Suggested Resume Order
 
 1. Create branch from updated `main`.
-2. Implement Priority 1 only.
+2. Implement Priority 7 only.
 3. Run local gates.
 4. Push and monitor remote CI and CodeQL.
 5. Address review comments and resolve conversations.
 6. Rebase/pull `main` after merge.
-7. Continue with Priority 2.
+7. Refresh this backlog before selecting the next slice.
 
-Avoid doing Priorities 2-6 in one PR. The App runtime is central; smaller PRs make review comments and CI failures easier to isolate.
+Avoid mixing the speculative `config.NewModule()` decision with unrelated runtime changes. It is a public API question and should be reviewed on its own.

--- a/eventbus/module/module.go
+++ b/eventbus/module/module.go
@@ -19,7 +19,7 @@ import (
 // The module provides:
 //   - *eventbus.EventBus for in-process pub/sub messaging
 func New() gaz.Module {
-	return gaz.NewModule("eventbus").
+	return gaz.NewModule(eventbus.ModuleName).
 		Provide(eventbus.Module).
 		Build()
 }

--- a/eventbus/module/module_test.go
+++ b/eventbus/module/module_test.go
@@ -13,6 +13,7 @@ func TestNew(t *testing.T) {
 	t.Run("creates valid module", func(t *testing.T) {
 		mod := New()
 		require.NotNil(t, mod)
+		require.Equal(t, eventbus.ModuleName, mod.Name())
 	})
 
 	// Note: gaz.App auto-registers *eventbus.EventBus in initializeSubsystems(),

--- a/eventbus/module_identity.go
+++ b/eventbus/module_identity.go
@@ -1,0 +1,4 @@
+package eventbus
+
+// ModuleName is the canonical identity for the eventbus module.
+const ModuleName = "eventbus"

--- a/health/module/module_test.go
+++ b/health/module/module_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Run("uses canonical module identity", func(t *testing.T) {
+		require.Equal(t, health.ModuleName, New().Name())
+	})
+
 	t.Run("creates module with default config", func(t *testing.T) {
 		app := gaz.New()
 		app.Use(New())

--- a/logger/module/module.go
+++ b/logger/module/module.go
@@ -26,7 +26,7 @@ import (
 func New() gaz.Module {
 	defaultCfg := logger.DefaultConfig()
 
-	return gaz.NewModule("logger").
+	return gaz.NewModule(logger.ModuleName).
 		Flags(defaultCfg.Flags).
 		Provide(configuredmodule.ProvideDefaulted[logger.Config, *logger.Config](
 			&defaultCfg,

--- a/logger/module/module_test.go
+++ b/logger/module/module_test.go
@@ -41,6 +41,10 @@ func (s *LoggerModuleTestSuite) TestModuleRegistration() {
 	s.Equal("info", cfg.LevelName())
 }
 
+func (s *LoggerModuleTestSuite) TestModuleName() {
+	s.Equal(logger.ModuleName, loggermod.New().Name())
+}
+
 func (s *LoggerModuleTestSuite) TestDefaultConfig() {
 	cfg := logger.DefaultConfig()
 

--- a/logger/module_identity.go
+++ b/logger/module_identity.go
@@ -1,0 +1,4 @@
+package logger
+
+// ModuleName is the canonical identity for the logger module.
+const ModuleName = "logger"

--- a/server/grpc/module.go
+++ b/server/grpc/module.go
@@ -164,7 +164,7 @@ func provideServer(c *gaz.Container) error {
 func NewModule() gaz.Module {
 	defaultCfg := DefaultConfig()
 
-	return gaz.NewModule("grpc").
+	return gaz.NewModule(ModuleName).
 		Flags(defaultCfg.Flags).
 		Provide(provideConfig(&defaultCfg)).
 		Provide(provideLoggingBundle).

--- a/server/grpc/module_identity.go
+++ b/server/grpc/module_identity.go
@@ -1,0 +1,4 @@
+package grpc
+
+// ModuleName is the canonical identity for the gRPC server module.
+const ModuleName = "grpc"

--- a/server/grpc/module_test.go
+++ b/server/grpc/module_test.go
@@ -16,6 +16,7 @@ func TestNewModule(t *testing.T) {
 
 		// Register module
 		module := NewModule()
+		require.Equal(t, ModuleName, module.Name())
 		// Apply module to app
 		err := module.Apply(app)
 		require.NoError(t, err)

--- a/server/http/module.go
+++ b/server/http/module.go
@@ -26,7 +26,7 @@ import (
 func NewModule() gaz.Module {
 	defaultCfg := DefaultConfig()
 
-	return gaz.NewModule("http").
+	return gaz.NewModule(ModuleName).
 		Flags(defaultCfg.Flags).
 		Provide(configuredmodule.ProvideValidated[Config, *Config](
 			&defaultCfg,

--- a/server/http/module_identity.go
+++ b/server/http/module_identity.go
@@ -1,0 +1,4 @@
+package http
+
+// ModuleName is the canonical identity for the HTTP server module.
+const ModuleName = "http"

--- a/server/http/module_test.go
+++ b/server/http/module_test.go
@@ -15,6 +15,7 @@ func TestNewModule(t *testing.T) {
 		app := gaz.New()
 
 		module := NewModule()
+		require.Equal(t, ModuleName, module.Name())
 		err := module.Apply(app)
 		require.NoError(t, err)
 

--- a/server/module.go
+++ b/server/module.go
@@ -30,6 +30,6 @@ import (
 //	app.Use(server.NewModule())
 func NewModule() gaz.Module {
 	return newUnifiedServerBridge().
-		configure(gaz.NewModule(unifiedServerBridgeModuleName)).
+		configure(gaz.NewModule(ModuleName)).
 		Build()
 }

--- a/server/module_identity.go
+++ b/server/module_identity.go
@@ -1,0 +1,4 @@
+package server
+
+// ModuleName is the canonical identity for the unified server bridge module.
+const ModuleName = "server"

--- a/server/module_test.go
+++ b/server/module_test.go
@@ -58,7 +58,7 @@ func TestNewModule(t *testing.T) {
 	// Test module name.
 	t.Run("module name", func(t *testing.T) {
 		module := NewModule()
-		require.Equal(t, "server", module.Name())
+		require.Equal(t, ModuleName, module.Name())
 	})
 }
 

--- a/server/otel/module.go
+++ b/server/otel/module.go
@@ -38,7 +38,7 @@ func (t *tracerProviderStopper) OnStop(ctx context.Context) error {
 func NewModule() gaz.Module {
 	defaultCfg := DefaultConfig()
 
-	return gaz.NewModule("otel").
+	return gaz.NewModule(ModuleName).
 		Flags(defaultCfg.Flags).
 		Provide(func(c *gaz.Container) error {
 			// Register Config provider

--- a/server/otel/module_identity.go
+++ b/server/otel/module_identity.go
@@ -1,0 +1,4 @@
+package otel
+
+// ModuleName is the canonical identity for the OpenTelemetry server module.
+const ModuleName = "otel"

--- a/server/otel/module_test.go
+++ b/server/otel/module_test.go
@@ -111,7 +111,7 @@ func TestNewModule_ModuleName(t *testing.T) {
 	module := NewModule()
 
 	// Module should have a name for debugging/logging
-	assert.Equal(t, "otel", module.Name())
+	assert.Equal(t, ModuleName, module.Name())
 }
 
 // Verify that the stopper implements proper cleanup.

--- a/server/unified_server_bridge.go
+++ b/server/unified_server_bridge.go
@@ -8,8 +8,6 @@ import (
 	"github.com/petabytecl/gaz/server/vanguard"
 )
 
-const unifiedServerBridgeModuleName = "server"
-
 // unifiedServerBridge owns the single-port transport composition rule.
 //
 // Standalone gRPC and Vanguard modules remain usable on their own. The bridge

--- a/server/vanguard/module.go
+++ b/server/vanguard/module.go
@@ -223,7 +223,7 @@ func provideServer(c *gaz.Container) error {
 func NewModule() gaz.Module {
 	defaultCfg := DefaultConfig()
 
-	return gaz.NewModule("vanguard").
+	return gaz.NewModule(ModuleName).
 		Flags(defaultCfg.Flags).
 		Provide(provideConfig(&defaultCfg)).
 		Provide(provideCORSMiddleware).

--- a/server/vanguard/module_identity.go
+++ b/server/vanguard/module_identity.go
@@ -1,0 +1,4 @@
+package vanguard
+
+// ModuleName is the canonical identity for the Vanguard server module.
+const ModuleName = "vanguard"

--- a/server/vanguard/module_test.go
+++ b/server/vanguard/module_test.go
@@ -33,7 +33,7 @@ func (s *ModuleTestSuite) TestNewModuleCreatesModule() {
 
 func (s *ModuleTestSuite) TestNewModuleName() {
 	mod := NewModule()
-	s.Equal("vanguard", mod.Name())
+	s.Equal(ModuleName, mod.Name())
 }
 
 func (s *ModuleTestSuite) TestProvideConfigDefaultValues() {

--- a/worker/module/module.go
+++ b/worker/module/module.go
@@ -19,7 +19,7 @@ import (
 // The module provides:
 //   - *worker.Manager for coordinating background workers
 func New() gaz.Module {
-	return gaz.NewModule("worker").
+	return gaz.NewModule(worker.ModuleName).
 		Provide(worker.Module).
 		Build()
 }

--- a/worker/module/module_test.go
+++ b/worker/module/module_test.go
@@ -13,6 +13,7 @@ func TestNew(t *testing.T) {
 	t.Run("creates valid module", func(t *testing.T) {
 		mod := New()
 		require.NotNil(t, mod)
+		require.Equal(t, worker.ModuleName, mod.Name())
 	})
 
 	t.Run("integrates with gaz.App", func(t *testing.T) {

--- a/worker/module_identity.go
+++ b/worker/module_identity.go
@@ -1,0 +1,4 @@
+package worker
+
+// ModuleName is the canonical identity for the worker module.
+const ModuleName = "worker"


### PR DESCRIPTION
## Summary
- expose canonical module identity constants from the owning config, logger, worker, cron, eventbus, and server packages
- switch module constructors and tests from ad hoc string names to those identities
- keep `config-flags` as an explicit flags-adapter identity, separate from config infrastructure
- document module identity in `CONTEXT.md` and refresh the architecture backlog so `config.NewModule()` is the next slice

## Notes
This is intended as a behavior-preserving architecture slice. It does not rename any existing module at runtime; it makes the current identities explicit and testable.

The local `make fmt-check` command returned success but printed the existing broken `goimports` shim noise from `.git` paths. I also ran the tracked-file goimports fallback over `git ls-files '*.go'`, which passed with no output.

## Test plan
- git diff --check
- make check
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod sh -c "git ls-files '*.go' | xargs go run golang.org/x/tools/cmd/goimports@latest -l"
- GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make lint
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./config ./config/module ./logger/module ./worker/module ./cron/module ./eventbus/module ./health/module ./server ./server/grpc ./server/http ./server/vanguard ./server/otel
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... -count=1
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make cover
