### PR TITLE
[codex] Deprecate no-op config module

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -4,46 +4,35 @@ import (
 	"github.com/petabytecl/gaz/di"
 )
 
-// ModuleOption configures the config module.
+// ModuleOption configures the deprecated compatibility config module.
+//
+// Deprecated: [NewModule] is a no-op compatibility module. Use gaz.App
+// WithConfig for application configuration, the config/module package for
+// Cobra config flags, or [New] for standalone configuration loading.
 type ModuleOption func(*moduleConfig)
 
-type moduleConfig struct {
-	// Currently no configurable options exposed
-	// Placeholder for future extensibility (e.g., WithWatcher)
-}
+type moduleConfig struct{}
 
-func defaultModuleConfig() *moduleConfig {
-	return &moduleConfig{}
-}
-
-// NewModule creates a config module with the given options.
-// Returns a di.Module that provides configuration infrastructure.
+// NewModule returns a no-op DI module kept for source compatibility.
 //
-// Note: Configuration is typically set up via gaz.App.WithConfig().
-// This module provides explicit opt-in for advanced use cases like
-// additional config sources or watchers.
+// The config package owns standalone configuration loading through [New].
+// gaz.App owns application configuration through WithConfig, and the
+// config/module package owns Cobra config flags. This compatibility module
+// deliberately registers no services.
 //
 // Example:
 //
 //	app := gaz.New()
 //	app.UseDI(config.NewModule())
+//
+// Deprecated: NewModule does not register configuration infrastructure. Use
+// gaz.App WithConfig for application configuration, the config/module package
+// for Cobra config flags, or [New] for standalone configuration loading.
 func NewModule(opts ...ModuleOption) di.Module {
-	cfg := defaultModuleConfig()
-	for _, opt := range opts {
-		opt(cfg)
-	}
+	_ = opts
 
 	return di.NewModuleFunc(ModuleName, func(c *di.Container) error {
-		// Config infrastructure is set up in gaz.New() and
-		// configured via WithConfig(). This module provides
-		// a placeholder for future extensions like:
-		// - Additional config sources
-		// - Config watchers
-		// - Remote config providers
-
-		_ = c   // Future: use container for registration
-		_ = cfg // Future: use cfg for configuration
-
+		_ = c
 		return nil
 	})
 }

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestNewModule(t *testing.T) {
-	t.Run("zero arguments works with defaults", func(t *testing.T) {
+	t.Run("is compatibility no-op", func(t *testing.T) {
 		c := di.New()
 
-		// Register module
 		module := NewModule()
 		err := module.Register(c)
 		require.NoError(t, err)
+		require.Empty(t, c.List())
 	})
 
 	t.Run("returns valid di.Module", func(t *testing.T) {
@@ -24,13 +24,13 @@ func TestNewModule(t *testing.T) {
 		require.Equal(t, ModuleName, mod.Name())
 	})
 
-	t.Run("accepts options", func(t *testing.T) {
-		// Test that options can be passed (even if none are currently defined)
-		mod := NewModule()
+	t.Run("ignores nil options", func(t *testing.T) {
+		mod := NewModule(nil)
 		require.NotNil(t, mod)
 
 		c := di.New()
 		err := mod.Register(c)
 		require.NoError(t, err)
+		require.Empty(t, c.List())
 	})
 }

--- a/docs/architecture-recommendations.md
+++ b/docs/architecture-recommendations.md
@@ -282,7 +282,7 @@ Suggested tests:
 
 Recommendation strength: Speculative
 
-Status: Next.
+Status: Completed.
 
 Files:
 
@@ -293,14 +293,11 @@ Files:
 
 Problem:
 
-`config.NewModule()` is currently a placeholder. The deletion test suggests it is shallow: deleting it would remove little behavior, but the public API may already imply that it has meaning.
+`config.NewModule()` was a placeholder. The deletion test showed it was shallow: deleting it would remove little behavior, but the public API already implied that it had meaning.
 
 Solution:
 
-Make an explicit decision:
-
-- Give it real behavior, such as registering config infrastructure or a documented config manager adapter.
-- Or document it as deprecated/no-op compatibility and stop presenting it as an advanced module.
+Document it as deprecated/no-op compatibility and stop presenting it as an advanced module.
 
 Benefits:
 
@@ -310,17 +307,20 @@ Benefits:
 
 Suggested tests:
 
-- If kept: assert the concrete behavior it owns.
-- If deprecated/no-op: assert it remains harmless and update docs to be explicit.
+- Assert it remains harmless and update docs to be explicit.
+
+## Current Architecture Review Status
+
+The architecture backlog created from the earlier review is now exhausted. Priorities 1 through 7 are complete. Before selecting another implementation slice, run a fresh architecture review against current `main` and create a new short backlog from live friction instead of continuing from this historical queue.
 
 ## Suggested Resume Order
 
 1. Create branch from updated `main`.
-2. Implement Priority 7 only.
+2. Run a fresh architecture review against current `main`.
 3. Run local gates.
 4. Push and monitor remote CI and CodeQL.
 5. Address review comments and resolve conversations.
 6. Rebase/pull `main` after merge.
 7. Refresh this backlog before selecting the next slice.
 
-Avoid mixing the speculative `config.NewModule()` decision with unrelated runtime changes. It is a public API question and should be reviewed on its own.
+Avoid inventing new work from this exhausted backlog. New work should come from current code evidence.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -244,6 +244,8 @@ Features:
 - Cobra integration
 - Structured logging
 
+Use `gaz.New().WithConfig(...)` for App-managed configuration. The `config.NewModule()` compatibility module is deprecated and intentionally registers nothing.
+
 ### Container (Libraries/Testing)
 
 Use `Container` directly for libraries or test scenarios:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,6 +178,8 @@ func main() {
 }
 ```
 
+Do not use `config.NewModule()` for new code. It is a deprecated compatibility no-op and does not register configuration infrastructure. Use `gaz.New().WithConfig(...)` for App-managed configuration, `config/module.New()` for Cobra config flags, or `config.New(...)` for standalone loading.
+
 **Supported file formats:**
 
 - YAML (`.yaml`, `.yml`)


### PR DESCRIPTION
## Summary
- mark `config.NewModule()` and `ModuleOption` as deprecated compatibility API
- make the no-op behavior explicit in implementation, tests, and user docs
- point callers to `gaz.New().WithConfig(...)`, `config/module.New()`, or `config.New(...)` depending on the configuration use case
- mark the historical architecture backlog as exhausted after Priority 7

## Notes
This keeps the public symbol and `config.ModuleName` stable for compatibility. The module still returns a valid `di.Module`, but its register function deliberately registers no services.

`make fmt-check` returned success but printed the existing broken `goimports` shim noise from `.git` paths. The tracked-file goimports fallback passed cleanly.

## Test plan
- git diff --check
- make check
- make fmt-check
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod sh -c "git ls-files '*.go' | xargs go run golang.org/x/tools/cmd/goimports@latest -l"
- GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make lint
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./config ./config/module
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... -count=1
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make cover
