### PR TITLE
[codex] Reuse explicit EventBus module in App runtime

### DIFF
--- a/docs/architecture-recommendations.md
+++ b/docs/architecture-recommendations.md
@@ -24,6 +24,7 @@ Already completed:
 - The App build sequence is named and testable through private build phases.
 - Config flag interpretation moved behind a private config flag policy.
 - Runtime subsystem construction moved behind a private runtime-subsystems module.
+- Explicit EventBus module registration composes with App runtime construction by reusing the registered bus.
 - Lifecycle session orchestration moved behind a private lifecycle session.
 - Feature module identities are exposed by the owning packages; config keeps a deliberately separate `config-flags` adapter identity.
 
@@ -309,9 +310,44 @@ Suggested tests:
 
 - Assert it remains harmless and update docs to be explicit.
 
+## Priority 8: Reuse Explicit EventBus Module Registrations
+
+Recommendation strength: Worth exploring
+
+Status: Completed.
+
+Files:
+
+- `runtime_subsystems.go`
+- `runtime_subsystems_test.go`
+- `eventbus/module.go`
+- `eventbus/module/module.go`
+- `eventbus/module/module_test.go`
+- `eventbus/doc.go`
+
+Problem:
+
+The fresh review found a runtime adapter mismatch: `eventbus/module.New()` told App callers to install the EventBus module, while the App runtime already auto-registered the framework EventBus during subsystem construction. Because subsystem construction rejected any existing `*eventbus.EventBus` registration, the documented `app.Use(eventbusmod.New())` composition failed instead of behaving as an explicit version of the same runtime participant.
+
+Solution:
+
+Move EventBus acquisition behind the runtime subsystem module. If the container already has `*eventbus.EventBus`, resolve and reuse it as the App-managed framework EventBus. If not, create and register the default bus as before.
+
+Benefits:
+
+- Runtime subsystem construction owns the EventBus composition rule instead of leaking it as a duplicate-registration surprise.
+- The public EventBus module becomes an honest App adapter as well as a standalone DI adapter.
+- Tests cover the App-facing contract directly.
+
+Suggested tests:
+
+- App builds successfully when `app.Use(eventbusmod.New())` is applied.
+- The App EventBus accessor and DI resolution return the same reused bus.
+- A failing explicit EventBus provider returns actionable build context.
+
 ## Current Architecture Review Status
 
-The architecture backlog created from the earlier review is now exhausted. Priorities 1 through 7 are complete. Before selecting another implementation slice, run a fresh architecture review against current `main` and create a new short backlog from live friction instead of continuing from this historical queue.
+The architecture backlog created from the earlier review is now exhausted. Priorities 1 through 8 are complete. Before selecting another implementation slice, run a fresh architecture review against current `main` and create a new short backlog from live friction instead of continuing from this historical queue.
 
 ## Suggested Resume Order
 

--- a/eventbus/doc.go
+++ b/eventbus/doc.go
@@ -43,6 +43,10 @@
 // system. It starts automatically with app.Run() and stops gracefully on shutdown,
 // draining in-flight events before returning.
 //
+// gaz.App creates an EventBus by default. If callers explicitly install
+// eventbus/module before Build, the App runtime reuses that bus instead of
+// creating a second one.
+//
 // # Usage Example
 //
 //	// Define an event

--- a/eventbus/module.go
+++ b/eventbus/module.go
@@ -10,7 +10,10 @@ import (
 // Module registers eventbus infrastructure into the DI container.
 // It provides a *EventBus for in-process pub/sub messaging.
 //
-// If *EventBus is already registered (e.g., by gaz.App), this is a no-op.
+// If *EventBus is already registered, this is a no-op. When this module is
+// registered before gaz.App.Build, the App-managed runtime reuses the provided
+// EventBus instead of creating a second bus.
+//
 // The logger is optional - if not registered, slog.Default() is used.
 //
 // For CLI/App integration with flags, use the eventbus/module subpackage:

--- a/eventbus/module/module.go
+++ b/eventbus/module/module.go
@@ -7,7 +7,8 @@ import (
 )
 
 // New creates an eventbus module that provides eventbus.EventBus.
-// This module registers the in-process pub/sub infrastructure.
+// This module registers the in-process pub/sub infrastructure. When used with
+// gaz.App, the App-managed runtime reuses this EventBus for lifecycle handling.
 //
 // Usage:
 //

--- a/eventbus/module/module_test.go
+++ b/eventbus/module/module_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/petabytecl/gaz"
 	"github.com/petabytecl/gaz/di"
 	"github.com/petabytecl/gaz/eventbus"
 )
@@ -16,9 +17,20 @@ func TestNew(t *testing.T) {
 		require.Equal(t, eventbus.ModuleName, mod.Name())
 	})
 
-	// Note: gaz.App auto-registers *eventbus.EventBus in initializeSubsystems(),
-	// so using eventbusmod.New() with gaz.App is redundant. The module is intended
-	// for di.Container usage or when the auto-registration behavior changes.
+	t.Run("works with gaz.App", func(t *testing.T) {
+		app := gaz.New()
+		app.Use(New())
+
+		require.NoError(t, app.Build())
+		require.NotNil(t, app.EventBus())
+
+		bus, err := gaz.Resolve[*eventbus.EventBus](app.Container())
+		require.NoError(t, err)
+		require.Same(t, app.EventBus(), bus)
+
+		bus.Close()
+	})
+
 	t.Run("works with di.Container directly", func(t *testing.T) {
 		c := di.New()
 

--- a/runtime_subsystems.go
+++ b/runtime_subsystems.go
@@ -45,21 +45,16 @@ func newRuntimeSubsystems(deps runtimeSubsystemsDeps) (*runtimeSubsystems, error
 	if deps.stopFunc == nil {
 		return nil, errors.New("runtime subsystems: stop function is required")
 	}
-	if Has[*eventbus.EventBus](deps.container) {
-		return nil, fmt.Errorf("%w: %s", ErrDIDuplicate, TypeName[*eventbus.EventBus]())
-	}
-
 	mgr := worker.NewManager(log)
 	mgr.SetCriticalFailHandler(criticalFailHandler(log, deps.shutdownTimeout, deps.stopFunc))
 
 	cronCtx, cronCancel := context.WithCancel(context.Background())
 	sched := cron.NewScheduler(deps.container, cronCtx, log)
 
-	bus := eventbus.New(log)
-
-	if err := For[*eventbus.EventBus](deps.container).Instance(bus); err != nil {
+	bus, err := runtimeEventBus(deps.container, log)
+	if err != nil {
 		cronCancel()
-		return nil, fmt.Errorf("register eventbus: %w", err)
+		return nil, err
 	}
 
 	return &runtimeSubsystems{
@@ -69,6 +64,25 @@ func newRuntimeSubsystems(deps runtimeSubsystemsDeps) (*runtimeSubsystems, error
 		cronCancel: cronCancel,
 		eventBus:   bus,
 	}, nil
+}
+
+func runtimeEventBus(container *Container, log *slog.Logger) (*eventbus.EventBus, error) {
+	if Has[*eventbus.EventBus](container) {
+		bus, err := Resolve[*eventbus.EventBus](container)
+		if err != nil {
+			return nil, fmt.Errorf("resolve eventbus: %w", err)
+		}
+		if bus == nil {
+			return nil, fmt.Errorf("%w: %s resolved to nil", ErrDIInvalidProvider, TypeName[*eventbus.EventBus]())
+		}
+		return bus, nil
+	}
+
+	bus := eventbus.New(log)
+	if err := For[*eventbus.EventBus](container).Instance(bus); err != nil {
+		return nil, fmt.Errorf("register eventbus: %w", err)
+	}
+	return bus, nil
 }
 
 func criticalFailHandler(log *slog.Logger, timeout time.Duration, stopFunc func(context.Context) error) func() {

--- a/runtime_subsystems_test.go
+++ b/runtime_subsystems_test.go
@@ -2,6 +2,7 @@ package gaz
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync/atomic"
 	"testing"
@@ -94,9 +95,37 @@ func TestCriticalFailHandler_TriggersShutdown(t *testing.T) {
 	require.Eventually(t, stopCalled.Load, 2*time.Second, 10*time.Millisecond)
 }
 
-func TestNewRuntimeSubsystems_DuplicateEventBusReturnsError(t *testing.T) {
+func TestNewRuntimeSubsystems_ReusesRegisteredEventBus(t *testing.T) {
 	container := NewContainer()
-	require.NoError(t, For[*eventbus.EventBus](container).Instance(eventbus.New(slog.Default())))
+	existing := eventbus.New(slog.Default())
+	defer existing.Close()
+
+	require.NoError(t, For[*eventbus.EventBus](container).Instance(existing))
+
+	subs, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       container,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+	require.Same(t, existing, subs.eventBus)
+
+	require.NoError(t, container.Build())
+
+	resolved, resolveErr := Resolve[*eventbus.EventBus](container)
+	require.NoError(t, resolveErr)
+	assert.Same(t, existing, resolved)
+}
+
+func TestNewRuntimeSubsystems_RegisteredEventBusResolveError(t *testing.T) {
+	container := NewContainer()
+	resolveErr := errors.New("eventbus provider failed")
+	require.NoError(t, For[*eventbus.EventBus](container).Provider(
+		func(*Container) (*eventbus.EventBus, error) {
+			return nil, resolveErr
+		},
+	))
 
 	_, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
 		logger:          slog.Default(),
@@ -104,7 +133,8 @@ func TestNewRuntimeSubsystems_DuplicateEventBusReturnsError(t *testing.T) {
 		shutdownTimeout: 5 * time.Second,
 		stopFunc:        func(context.Context) error { return nil },
 	})
-	require.ErrorIs(t, err, ErrDIDuplicate)
+	require.ErrorIs(t, err, resolveErr)
+	require.Contains(t, err.Error(), "resolve eventbus")
 }
 
 func TestNewRuntimeSubsystems_NilContainerReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary

- reuse an explicitly registered `*eventbus.EventBus` during App runtime subsystem construction
- make `eventbus/module.New()` compose with `gaz.App` instead of triggering a duplicate EventBus registration
- document the EventBus module/App composition rule and record the fresh architecture slice in the backlog

## Why

The fresh architecture pass found that `eventbus/module.New()` documented `app.Use(eventbusmod.New())`, but App runtime construction also installed the framework EventBus and rejected any existing `*eventbus.EventBus` registration. That made the public module adapter misleading for App callers.

This change moves the composition rule behind the runtime subsystem module: if the container already has an EventBus, App resolves and reuses it as the lifecycle-managed framework bus; otherwise it creates the default bus as before.

## Validation

- [x] `git diff --check`
- [x] `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./eventbus ./eventbus/module . -run 'Test(NewRuntimeSubsystems|New)$|TestNew$|TestNewRuntimeSubsystems|TestEventBus'`
- [x] `make check`
- [x] `make fmt-check` (exit 0; local `goimports` shim still prints known `.git`/mise noise)
- [x] `git ls-files -z '*.go' | xargs -0 env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go run golang.org/x/tools/cmd/goimports@latest -l`
- [x] `GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make lint`
- [x] `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... -count=1` (rerun with socket permission after sandbox-local socket denial)
- [x] `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make cover` (rerun with socket permission after sandbox-local socket denial, coverage 91.1%)

## Security

- [x] No hardcoded secrets found in the diff.
- [x] No new user input, SQL, HTML rendering, authentication, authorization, CSRF, or rate-limited endpoint surface added.
