### PR TITLE
[codex] Publish App runtime subsystems through DI

### DIFF
--- a/app_build.go
+++ b/app_build.go
@@ -101,6 +101,18 @@ var workerType = reflect.TypeOf((*worker.Worker)(nil)).Elem()
 //nolint:gochecknoglobals // Package-level for reflect type caching.
 var eventBusType = reflect.TypeOf((*eventbus.EventBus)(nil))
 
+// workerManagerType is cached so the lifecycle plan can recognize the
+// framework worker manager registration without registering it with itself.
+//
+//nolint:gochecknoglobals // Package-level for reflect type caching.
+var workerManagerType = reflect.TypeOf((*worker.Manager)(nil))
+
+// cronSchedulerType is cached so the lifecycle plan can recognize the
+// framework scheduler registration without registering it as a user worker.
+//
+//nolint:gochecknoglobals // Package-level for reflect type caching.
+var cronSchedulerType = reflect.TypeOf((*cron.Scheduler)(nil))
+
 // cronJobType is cached for efficient interface checks during discovery.
 //
 //nolint:gochecknoglobals // Package-level for reflect type caching.

--- a/app_test.go
+++ b/app_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/petabytecl/gaz/di"
 	"github.com/petabytecl/gaz/eventbus"
 	"github.com/petabytecl/gaz/logger"
+	"github.com/petabytecl/gaz/worker"
 )
 
 type AppTestSuite struct {
@@ -517,6 +518,19 @@ func (s *AppTestSuite) TestEventBus() {
 	resolvedEventBus, err := Resolve[*eventbus.EventBus](app.Container())
 	s.Require().NoError(err)
 	s.Same(eventBusAfter, resolvedEventBus, "Resolved EventBus should be the same as accessor")
+}
+
+func (s *AppTestSuite) TestRuntimeSubsystemsResolvableFromDI() {
+	app := New()
+	s.Require().NoError(app.Build())
+
+	resolvedManager, err := Resolve[*worker.Manager](app.Container())
+	s.Require().NoError(err)
+	s.Same(app.workerMgr, resolvedManager)
+
+	resolvedScheduler, err := Resolve[*cron.Scheduler](app.Container())
+	s.Require().NoError(err)
+	s.Same(app.scheduler, resolvedScheduler)
 }
 
 func (s *AppTestSuite) TestWithLoggerConfig() {

--- a/cron/module.go
+++ b/cron/module.go
@@ -11,6 +11,10 @@ import (
 // Module registers cron infrastructure into the DI container.
 // It provides a *Scheduler that can schedule and execute cron jobs.
 //
+// When registered before gaz.App.Build, the App-managed runtime publishes its
+// scheduler as *Scheduler so DI resolution matches the scheduler App starts and
+// stops. Standalone DI usage keeps the scheduler created here.
+//
 // The logger is optional - if not registered, slog.Default() is used.
 // The di.Container is used as the Resolver since it implements ResolveByName.
 //

--- a/cron/module/module.go
+++ b/cron/module/module.go
@@ -8,6 +8,8 @@ import (
 
 // New creates a cron module that provides cron.Scheduler.
 // This module registers the cron infrastructure for scheduling jobs.
+// When used with gaz.App, DI resolution returns the App-managed scheduler
+// that receives the App shutdown context.
 //
 // Usage:
 //

--- a/docs/architecture-recommendations.md
+++ b/docs/architecture-recommendations.md
@@ -25,6 +25,7 @@ Already completed:
 - Config flag interpretation moved behind a private config flag policy.
 - Runtime subsystem construction moved behind a private runtime-subsystems module.
 - Explicit EventBus module registration composes with App runtime construction by reusing the registered bus.
+- App-managed worker manager and cron scheduler are published through DI as the same instances App starts and stops.
 - Lifecycle session orchestration moved behind a private lifecycle session.
 - Feature module identities are exposed by the owning packages; config keeps a deliberately separate `config-flags` adapter identity.
 
@@ -345,9 +346,52 @@ Suggested tests:
 - The App EventBus accessor and DI resolution return the same reused bus.
 - A failing explicit EventBus provider returns actionable build context.
 
+## Priority 9: Publish App Runtime Subsystems Through DI
+
+Recommendation strength: Strong
+
+Status: Completed.
+
+Files:
+
+- `runtime_subsystems.go`
+- `runtime_subsystems_test.go`
+- `lifecycle_plan.go`
+- `lifecycle_plan_test.go`
+- `app_build.go`
+- `app_test.go`
+- `worker/module.go`
+- `worker/module/module.go`
+- `cron/module.go`
+- `cron/module/module.go`
+- `examples/background-workers/main.go`
+- `examples/microservice/main.go`
+- `docs/troubleshooting.md`
+
+Problem:
+
+The fresh review found the same adapter mismatch around worker and cron runtime infrastructure. App owned private runtime instances for `*worker.Manager` and `*cron.Scheduler`, while the worker and cron modules registered separately resolvable instances in DI. That made `app.Use(workermod.New())` and `app.Use(cronmod.New())` appear to affect App-managed runtime behavior even though App started and stopped different objects.
+
+Solution:
+
+Publish the App-managed worker manager and cron scheduler into DI during runtime subsystem construction. If a worker manager was explicitly registered, reuse it and apply App's critical worker failure handler. Always publish the App-managed cron scheduler so jobs receive the App shutdown context. Extend lifecycle plan classification so these framework runtime registrations are not reclassified as user workers.
+
+Benefits:
+
+- DI resolution now returns the same runtime objects App starts and stops.
+- Worker and cron module adapters become honest App composition points instead of parallel standalone infrastructure.
+- Lifecycle planning keeps a clearer distinction between framework runtime participants and user workers/jobs.
+
+Suggested tests:
+
+- App-managed worker manager and cron scheduler resolve from DI after Build.
+- An explicitly registered worker manager is reused by runtime subsystem construction.
+- A pre-registered cron scheduler is replaced by the App-managed scheduler.
+- Lifecycle planning excludes framework runtime participants from user worker classification.
+
 ## Current Architecture Review Status
 
-The architecture backlog created from the earlier review is now exhausted. Priorities 1 through 8 are complete. Before selecting another implementation slice, run a fresh architecture review against current `main` and create a new short backlog from live friction instead of continuing from this historical queue.
+The architecture backlog created from the earlier review is now exhausted. Priorities 1 through 9 are complete. Before selecting another implementation slice, run a fresh architecture review against current `main` and create a new short backlog from live friction instead of continuing from this historical queue.
 
 ## Suggested Resume Order
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -255,15 +255,12 @@ app.Module("cache", ...)
 
 **Problem:** Registered worker never starts.
 
-**Cause:** Worker not properly registered or module not loaded.
+**Cause:** Worker not properly registered, or the app was built but never run.
 
 **Solution:**
 
 ```go
-// Register worker module
-app.UseDI(worker.NewModule())
-
-// Register your worker
+// Register your worker. gaz.App owns the runtime worker manager.
 gaz.For[worker.Worker](app.Container()).
     Named("my-worker").
     Provider(NewMyWorker)

--- a/examples/background-workers/main.go
+++ b/examples/background-workers/main.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/petabytecl/gaz"
 	"github.com/petabytecl/gaz/worker"
-	workermod "github.com/petabytecl/gaz/worker/module"
 )
 
 // EmailWorker processes an email queue in the background.
@@ -136,9 +135,6 @@ var (
 
 func run(ctx context.Context) error {
 	app := gaz.New()
-
-	// Register worker module (provides worker.Manager)
-	app.Use(workermod.New())
 
 	// Register EmailWorker as an eager singleton.
 	// Eager() ensures OnStart() is called during app.Run().

--- a/examples/microservice/main.go
+++ b/examples/microservice/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/petabytecl/gaz/eventbus"
 	healthmod "github.com/petabytecl/gaz/health/module"
 	"github.com/petabytecl/gaz/worker"
-	workermod "github.com/petabytecl/gaz/worker/module"
 )
 
 // --- Events ---
@@ -262,9 +261,6 @@ func run(ctx context.Context) error {
 	// Health module: provides /live, /ready, /startup endpoints
 	// Note: --health-port flag allows overriding the port via CLI
 	app.Use(healthmod.New())
-
-	// Worker module: provides worker.Manager
-	app.Use(workermod.New())
 
 	// Note: EventBus is auto-registered by gaz.App, no module needed
 

--- a/lifecycle_plan.go
+++ b/lifecycle_plan.go
@@ -83,6 +83,10 @@ func collectLifecyclePlanServices(container *Container) map[string]di.ServiceWra
 			return
 		}
 
+		if isFrameworkRuntimeService(svc) {
+			return
+		}
+
 		if isWorkerParticipant(svc) || isCronJobParticipant(svc) {
 			return
 		}
@@ -128,7 +132,7 @@ func collectRuntimeParticipants(container *Container) ([]lifecycleWorkerParticip
 
 	container.ForEachService(func(name string, svc di.ServiceWrapper) {
 		if isWorkerParticipant(svc) {
-			if isFrameworkEventBus(svc) {
+			if isFrameworkRuntimeWorker(svc) {
 				return
 			}
 			workerParticipants = append(workerParticipants, lifecycleWorkerParticipant{
@@ -148,9 +152,13 @@ func isWorkerParticipant(svc di.ServiceWrapper) bool {
 	return st != nil && st.Implements(workerType)
 }
 
-func isFrameworkEventBus(svc di.ServiceWrapper) bool {
+func isFrameworkRuntimeWorker(svc di.ServiceWrapper) bool {
+	return isFrameworkRuntimeService(svc)
+}
+
+func isFrameworkRuntimeService(svc di.ServiceWrapper) bool {
 	st := svc.ServiceType()
-	return st == eventBusType
+	return st == eventBusType || st == workerManagerType || st == cronSchedulerType
 }
 
 func isCronJobParticipant(svc di.ServiceWrapper) bool {

--- a/lifecycle_plan_test.go
+++ b/lifecycle_plan_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/petabytecl/gaz/cron"
+	"github.com/petabytecl/gaz/eventbus"
 	"github.com/petabytecl/gaz/worker"
 )
 
@@ -153,6 +154,25 @@ func TestLifecyclePlanOwnsSelectionAndOrderPolicy(t *testing.T) {
 	require.Len(t, plan.cronJobs, 1)
 	assert.Equal(t, "cron-job", plan.cronJobs[0].serviceName)
 	assert.True(t, plan.cronJobs[0].transient)
+}
+
+func TestLifecyclePlanExcludesFrameworkRuntimeParticipants(t *testing.T) {
+	c := NewContainer()
+
+	require.NoError(t, For[*worker.Manager](c).Instance(worker.NewManager(slog.Default())))
+	require.NoError(t, For[*cron.Scheduler](c).Instance(
+		cron.NewScheduler(c, context.Background(), slog.Default()),
+	))
+	require.NoError(t, For[*eventbus.EventBus](c).Instance(eventbus.New(slog.Default())))
+
+	require.NoError(t, c.Build())
+
+	plan, err := newLifecyclePlan(c)
+	require.NoError(t, err)
+
+	assert.Empty(t, plan.services)
+	assert.Empty(t, plan.workerParticipants)
+	assert.Empty(t, plan.cronJobs)
 }
 
 func TestLifecyclePlanDoesNotResolvePlainServicesDuringPlanning(t *testing.T) {

--- a/runtime_subsystems.go
+++ b/runtime_subsystems.go
@@ -45,11 +45,17 @@ func newRuntimeSubsystems(deps runtimeSubsystemsDeps) (*runtimeSubsystems, error
 	if deps.stopFunc == nil {
 		return nil, errors.New("runtime subsystems: stop function is required")
 	}
-	mgr := worker.NewManager(log)
-	mgr.SetCriticalFailHandler(criticalFailHandler(log, deps.shutdownTimeout, deps.stopFunc))
+	mgr, err := runtimeWorkerManager(deps.container, log, deps.shutdownTimeout, deps.stopFunc)
+	if err != nil {
+		return nil, err
+	}
 
 	cronCtx, cronCancel := context.WithCancel(context.Background())
 	sched := cron.NewScheduler(deps.container, cronCtx, log)
+	if regErr := registerRuntimeScheduler(deps.container, sched); regErr != nil {
+		cronCancel()
+		return nil, regErr
+	}
 
 	bus, err := runtimeEventBus(deps.container, log)
 	if err != nil {
@@ -64,6 +70,39 @@ func newRuntimeSubsystems(deps runtimeSubsystemsDeps) (*runtimeSubsystems, error
 		cronCancel: cronCancel,
 		eventBus:   bus,
 	}, nil
+}
+
+func runtimeWorkerManager(
+	container *Container,
+	log *slog.Logger,
+	shutdownTimeout time.Duration,
+	stopFunc func(context.Context) error,
+) (*worker.Manager, error) {
+	if Has[*worker.Manager](container) {
+		mgr, err := Resolve[*worker.Manager](container)
+		if err != nil {
+			return nil, fmt.Errorf("resolve worker manager: %w", err)
+		}
+		if mgr == nil {
+			return nil, fmt.Errorf("%w: %s resolved to nil", ErrDIInvalidProvider, TypeName[*worker.Manager]())
+		}
+		mgr.SetCriticalFailHandler(criticalFailHandler(log, shutdownTimeout, stopFunc))
+		return mgr, nil
+	}
+
+	mgr := worker.NewManager(log)
+	mgr.SetCriticalFailHandler(criticalFailHandler(log, shutdownTimeout, stopFunc))
+	if err := For[*worker.Manager](container).Instance(mgr); err != nil {
+		return nil, fmt.Errorf("register worker manager: %w", err)
+	}
+	return mgr, nil
+}
+
+func registerRuntimeScheduler(container *Container, scheduler *cron.Scheduler) error {
+	if err := For[*cron.Scheduler](container).Replace().Instance(scheduler); err != nil {
+		return fmt.Errorf("register cron scheduler: %w", err)
+	}
+	return nil
 }
 
 func runtimeEventBus(container *Container, log *slog.Logger) (*eventbus.EventBus, error) {

--- a/runtime_subsystems_test.go
+++ b/runtime_subsystems_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/petabytecl/gaz/cron"
 	"github.com/petabytecl/gaz/eventbus"
+	"github.com/petabytecl/gaz/worker"
 )
 
-func TestNewRuntimeSubsystems_RegistersEventBusInDI(t *testing.T) {
+func TestNewRuntimeSubsystems_RegistersRuntimeParticipantsInDI(t *testing.T) {
 	container := NewContainer()
 
 	subs, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
@@ -24,9 +26,19 @@ func TestNewRuntimeSubsystems_RegistersEventBusInDI(t *testing.T) {
 		stopFunc:        func(context.Context) error { return nil },
 	})
 	require.NoError(t, err)
+	require.NotNil(t, subs.workerMgr)
+	require.NotNil(t, subs.scheduler)
 	require.NotNil(t, subs.eventBus)
 
 	require.NoError(t, container.Build())
+
+	resolvedManager, resolveManagerErr := Resolve[*worker.Manager](container)
+	require.NoError(t, resolveManagerErr)
+	assert.Same(t, subs.workerMgr, resolvedManager)
+
+	resolvedScheduler, resolveSchedulerErr := Resolve[*cron.Scheduler](container)
+	require.NoError(t, resolveSchedulerErr)
+	assert.Same(t, subs.scheduler, resolvedScheduler)
 
 	resolved, resolveErr := Resolve[*eventbus.EventBus](container)
 	require.NoError(t, resolveErr)
@@ -72,6 +84,67 @@ func TestNewRuntimeSubsystems_SchedulerContextCancellable(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("context should be cancelled after cronCancel()")
 	}
+}
+
+func TestNewRuntimeSubsystems_ReusesRegisteredWorkerManager(t *testing.T) {
+	container := NewContainer()
+	existing := worker.NewManager(slog.Default())
+	require.NoError(t, For[*worker.Manager](container).Instance(existing))
+
+	subs, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       container,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+	require.Same(t, existing, subs.workerMgr)
+
+	require.NoError(t, container.Build())
+
+	resolved, resolveErr := Resolve[*worker.Manager](container)
+	require.NoError(t, resolveErr)
+	assert.Same(t, existing, resolved)
+}
+
+func TestNewRuntimeSubsystems_RegisteredWorkerManagerResolveError(t *testing.T) {
+	container := NewContainer()
+	resolveErr := errors.New("worker manager provider failed")
+	require.NoError(t, For[*worker.Manager](container).Provider(
+		func(*Container) (*worker.Manager, error) {
+			return nil, resolveErr
+		},
+	))
+
+	_, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       container,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.ErrorIs(t, err, resolveErr)
+	require.Contains(t, err.Error(), "resolve worker manager")
+}
+
+func TestNewRuntimeSubsystems_ReplacesRegisteredCronScheduler(t *testing.T) {
+	container := NewContainer()
+	existing := cron.NewScheduler(container, context.Background(), slog.Default())
+	require.NoError(t, For[*cron.Scheduler](container).Instance(existing))
+
+	subs, err := newRuntimeSubsystems(runtimeSubsystemsDeps{
+		logger:          slog.Default(),
+		container:       container,
+		shutdownTimeout: 5 * time.Second,
+		stopFunc:        func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+	require.NotSame(t, existing, subs.scheduler)
+
+	require.NoError(t, container.Build())
+
+	resolved, resolveErr := Resolve[*cron.Scheduler](container)
+	require.NoError(t, resolveErr)
+	assert.Same(t, subs.scheduler, resolved)
 }
 
 func TestCriticalFailHandler_TriggersShutdown(t *testing.T) {

--- a/worker/module.go
+++ b/worker/module.go
@@ -10,6 +10,9 @@ import (
 // Module registers worker infrastructure into the DI container.
 // It provides a *Manager that can coordinate background workers.
 //
+// When registered before gaz.App.Build, the App-managed runtime reuses this
+// Manager and applies its critical worker failure handler.
+//
 // The logger is optional - if not registered, slog.Default() is used.
 //
 // For CLI/App integration with flags, use the worker/module subpackage:

--- a/worker/module/module.go
+++ b/worker/module/module.go
@@ -8,6 +8,8 @@ import (
 
 // New creates a worker module that provides worker.Manager.
 // This module registers the worker infrastructure for managing background workers.
+// When used with gaz.App, the App-managed runtime reuses this Manager and
+// applies its critical worker failure handler.
 //
 // Usage:
 //


### PR DESCRIPTION
## Summary

- publish the App-managed `*worker.Manager` and `*cron.Scheduler` through DI
- reuse an explicit worker manager while applying App's critical-worker shutdown hook
- replace standalone cron scheduler registrations with the App-managed scheduler so DI matches lifecycle behavior
- exclude framework runtime registrations from lifecycle service/worker classification
- remove redundant worker module usage from examples and document the updated App runtime ownership rule

## Why

The fresh architecture pass found the same adapter mismatch around worker and cron infrastructure that the EventBus slice fixed. App owned private runtime instances, while worker/cron modules could register separate DI-resolvable instances. That made `app.Use(workermod.New())` and `app.Use(cronmod.New())` look like they affected the App runtime even when App started and stopped different objects.

This change puts the runtime subsystem module in charge of publishing the objects App actually owns.

## Validation

- [x] `git diff --check`
- [x] `make check`
- [x] `make fmt-check` (exit 0; local `goimports` shim still prints known `.git`/mise noise)
- [x] `git ls-files -z '*.go' | xargs -0 env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go run golang.org/x/tools/cmd/goimports@latest -l`
- [x] `GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make lint`
- [x] `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test . ./worker/module ./cron/module ./examples/background-workers ./examples/microservice -run 'Test(NewRuntimeSubsystems|LifecyclePlanExcludes|AppTestSuite|New)$|TestNew$|TestRun'` (rerun with socket permission for microservice health startup)
- [x] `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... -count=1`
- [x] `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make cover` (coverage 91.1%)

## Security

- [x] No hardcoded secrets found in the diff.
- [x] No new user input, SQL, HTML rendering, authentication, authorization, CSRF, or rate-limited endpoint surface added.
