### PR TITLE
refactor: deepen module config seams

### DIFF
--- a/app_build.go
+++ b/app_build.go
@@ -129,10 +129,6 @@ func (a *App) Build() error {
 		return nil
 	}
 
-	if err := a.loadConfig(); err != nil {
-		return err
-	}
-
 	if err := a.runBuildPhases(); err != nil {
 		return err
 	}

--- a/app_module.go
+++ b/app_module.go
@@ -1,8 +1,6 @@
 package gaz
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // Module registers a named group of providers.
 // The name is used for debugging and error messages.
@@ -24,13 +22,10 @@ func (a *App) Module(name string, registrations ...func(*Container) error) *App 
 		panic("gaz: cannot add modules after Build()")
 	}
 
-	// Check for duplicate module name
-	if a.modules[name] {
-		a.buildErrors = append(a.buildErrors,
-			fmt.Errorf("%w: %s", ErrModuleDuplicate, name))
+	if err := a.registerModuleIdentity(name); err != nil {
+		a.buildErrors = append(a.buildErrors, err)
 		return a
 	}
-	a.modules[name] = true
 
 	// Register each provider with module context
 	for _, reg := range registrations {

--- a/app_use.go
+++ b/app_use.go
@@ -9,10 +9,8 @@ import (
 // Use applies a module to the app's container.
 // Modules bundle providers, configs, and other modules for reuse.
 //
-// Use accepts both gaz.Module (built via gaz.NewModule().Build()) and
-// di.Module (returned by subsystem packages like worker.NewModule()).
-// This allows subsystem packages to export modules without importing gaz,
-// avoiding import cycles.
+// Use accepts gaz.Module values built via gaz.NewModule().Build() or returned
+// by feature module packages.
 //
 // Child modules bundled via ModuleBuilder.Use() are applied BEFORE the
 // parent module's providers. This is for composition convenience, not
@@ -35,7 +33,6 @@ import (
 //
 //	app := gaz.New().
 //	    Use(module).
-//	    Use(worker.NewModule()).    // di.Module from subsystem
 //	    Use(cacheModule).
 //	    Build()
 func (a *App) Use(m Module) *App {
@@ -45,13 +42,10 @@ func (a *App) Use(m Module) *App {
 
 	name := m.Name()
 
-	// Check for duplicate module name
-	if a.modules[name] {
-		a.buildErrors = append(a.buildErrors,
-			fmt.Errorf("%w: %s", ErrModuleDuplicate, name))
+	if err := a.registerModuleIdentity(name); err != nil {
+		a.buildErrors = append(a.buildErrors, err)
 		return a
 	}
-	a.modules[name] = true
 
 	// Apply the module (which applies child modules first, then providers)
 	if err := m.Apply(a); err != nil {
@@ -63,8 +57,6 @@ func (a *App) Use(m Module) *App {
 }
 
 // UseDI applies a di.Module to the app's container.
-// This is for subsystem packages (health, worker, cron, eventbus) that
-// return di.Module to avoid import cycles with the gaz package.
 //
 // The di.Module interface has Register(c *Container) instead of Apply(app *App),
 // which allows subsystem packages to export modules without importing gaz.
@@ -72,7 +64,7 @@ func (a *App) Use(m Module) *App {
 // Example:
 //
 //	app := gaz.New().
-//	    UseDI(worker.NewModule()).
+//	    UseDI(di.NewModuleFunc("custom", registerCustom)).
 //	    Build()
 func (a *App) UseDI(m di.Module) *App {
 	if a.built {
@@ -81,13 +73,10 @@ func (a *App) UseDI(m di.Module) *App {
 
 	name := m.Name()
 
-	// Check for duplicate module name
-	if a.modules[name] {
-		a.buildErrors = append(a.buildErrors,
-			fmt.Errorf("%w: %s", ErrModuleDuplicate, name))
+	if err := a.registerModuleIdentity(name); err != nil {
+		a.buildErrors = append(a.buildErrors, err)
 		return a
 	}
-	a.modules[name] = true
 
 	// Apply the module by calling Register on the container
 	if err := m.Register(a.container); err != nil {

--- a/build_sequence.go
+++ b/build_sequence.go
@@ -7,15 +7,17 @@ import (
 
 // buildPhase names a unit of work in the build pipeline.
 type buildPhase struct {
-	name  string
-	run   func() error
-	gated bool // only runs if no prior phase produced an error
+	name        string
+	run         func() error
+	gated       bool // only runs if no prior phase produced an error
+	stopOnError bool // stops later phases when this phase fails
 }
 
 // buildPhaseOrder returns the named build phases in their required execution
 // order. The ordering contracts documented here are verified by tests.
 //
 // Ordering contracts:
+//   - load-config before register-provider-values
 //   - register-provider-values before collect-provider-configs
 //   - initialize-logger before initialize-subsystems
 //   - build-container before create-lifecycle-plan
@@ -23,6 +25,7 @@ type buildPhase struct {
 //   - resolve-lifecycle-services before register-runtime-participants
 func (a *App) buildPhaseOrder() []buildPhase {
 	return []buildPhase{
+		{name: "load-config", run: a.loadConfig, stopOnError: true},
 		{name: "register-provider-values", run: a.registerProviderValuesEarly},
 		{name: "initialize-logger", run: a.initializeLogger},
 		{name: "initialize-subsystems", run: a.initializeSubsystems},
@@ -48,6 +51,9 @@ func (a *App) runBuildPhases() error {
 		}
 		if err := phase.run(); err != nil {
 			errs = append(errs, err)
+			if phase.stopOnError {
+				break
+			}
 		}
 	}
 

--- a/build_sequence_test.go
+++ b/build_sequence_test.go
@@ -16,6 +16,18 @@ func phaseIndex(phases []buildPhase, name string) int {
 	return -1
 }
 
+func TestBuildPhaseOrder_LoadConfigBeforeProviderValues(t *testing.T) {
+	app := New()
+	phases := app.buildPhaseOrder()
+
+	lc := phaseIndex(phases, "load-config")
+	pv := phaseIndex(phases, "register-provider-values")
+
+	require.NotEqual(t, -1, lc)
+	require.NotEqual(t, -1, pv)
+	assert.Less(t, lc, pv)
+}
+
 func TestBuildPhaseOrder_ProviderValuesBeforeCollectConfigs(t *testing.T) {
 	app := New()
 	phases := app.buildPhaseOrder()

--- a/config/testing.go
+++ b/config/testing.go
@@ -1,9 +1,13 @@
 package config
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // =============================================================================
@@ -123,19 +127,118 @@ func (b *MapBackend) IsSet(key string) bool {
 	return ok
 }
 
-// Unmarshal unmarshals the entire config into a struct.
-// For testing, this performs a simple field matching by key.
-// It does not support nested structs or complex types.
-func (b *MapBackend) Unmarshal(_ any) error {
-	// Simple implementation - in tests, values are typically accessed directly
-	// or the test uses a viper backend for complex unmarshaling needs.
+// Unmarshal unmarshals the entire config into a struct using mapstructure tags.
+func (b *MapBackend) Unmarshal(target any) error {
+	return b.decode(target, b.nestedValues(), "mapstructure")
+}
+
+// UnmarshalKey unmarshals a specific key into a struct using mapstructure tags.
+func (b *MapBackend) UnmarshalKey(key string, target any) error {
+	value, ok := b.valueForKey(key)
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrKeyNotFound, key)
+	}
+	return b.decode(target, value, "mapstructure")
+}
+
+// UnmarshalWithGazTag unmarshals the entire config into a struct using gaz tags.
+func (b *MapBackend) UnmarshalWithGazTag(target any) error {
+	return b.decode(target, b.nestedValues(), "gaz")
+}
+
+// UnmarshalKeyWithGazTag unmarshals a specific key into a struct using gaz tags.
+func (b *MapBackend) UnmarshalKeyWithGazTag(key string, target any) error {
+	value, ok := b.valueForKey(key)
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrKeyNotFound, key)
+	}
+	return b.decode(target, value, "gaz")
+}
+
+// HasKey returns true when the exact key or a child namespace is present.
+func (b *MapBackend) HasKey(key string) bool {
+	_, ok := b.valueForKey(key)
+	return ok
+}
+
+func (b *MapBackend) decode(target, value any, tagName string) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           target,
+		TagName:          tagName,
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
+		return fmt.Errorf("config: create decoder: %w", err)
+	}
+	if decodeErr := decoder.Decode(value); decodeErr != nil {
+		return fmt.Errorf("config: unmarshal: %w", decodeErr)
+	}
 	return nil
 }
 
-// UnmarshalKey unmarshals a specific key into a struct.
-// For testing, this is a no-op - use Get* methods for value access.
-func (b *MapBackend) UnmarshalKey(_ string, _ any) error {
-	return nil
+func (b *MapBackend) valueForKey(key string) (any, bool) {
+	values := b.mergedValues()
+	if value, ok := values[key]; ok {
+		return value, true
+	}
+
+	prefix := key + "."
+	nested := make(map[string]any)
+	found := false
+	for valueKey, value := range values {
+		if strings.HasPrefix(valueKey, prefix) {
+			found = true
+			assignNested(nested, strings.TrimPrefix(valueKey, prefix), value)
+		}
+	}
+	if found {
+		return nested, true
+	}
+
+	return nil, false
+}
+
+func (b *MapBackend) nestedValues() map[string]any {
+	nested := make(map[string]any)
+	for key, value := range b.mergedValues() {
+		assignNested(nested, key, value)
+	}
+	return nested
+}
+
+func (b *MapBackend) mergedValues() map[string]any {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	values := make(map[string]any, len(b.defaults)+len(b.values))
+	for key, value := range b.defaults {
+		values[key] = value
+	}
+	for key, value := range b.values {
+		values[key] = value
+	}
+	return values
+}
+
+func assignNested(root map[string]any, key string, value any) {
+	parts := strings.Split(key, ".")
+	current := root
+	for index, part := range parts {
+		if part == "" {
+			continue
+		}
+		if index == len(parts)-1 {
+			current[part] = value
+			return
+		}
+
+		child, ok := current[part].(map[string]any)
+		if !ok {
+			child = make(map[string]any)
+			current[part] = child
+		}
+		current = child
+	}
 }
 
 // =============================================================================

--- a/config/testing_test.go
+++ b/config/testing_test.go
@@ -232,20 +232,24 @@ func TestRequireConfigIsSet(t *testing.T) {
 func TestMapBackend_Unmarshal(t *testing.T) {
 	t.Parallel()
 	backend := config.NewMapBackend(map[string]any{
-		"host": "localhost",
-		"port": 8080,
+		"host":           "localhost",
+		"port":           8080,
+		"nested.enabled": true,
 	})
 
-	// Unmarshal is a no-op for MapBackend but should not error
 	type cfg struct {
-		Host string
-		Port int
+		Host   string
+		Port   int
+		Nested struct {
+			Enabled bool `mapstructure:"enabled"`
+		} `mapstructure:"nested"`
 	}
 	var c cfg
 	err := backend.Unmarshal(&c)
 	require.NoError(t, err)
-	// Note: MapBackend.Unmarshal is a no-op, so values won't be populated
-	// This is documented behavior - use Get* methods instead
+	assert.Equal(t, "localhost", c.Host)
+	assert.Equal(t, 8080, c.Port)
+	assert.True(t, c.Nested.Enabled)
 }
 
 func TestMapBackend_UnmarshalKey(t *testing.T) {
@@ -255,7 +259,6 @@ func TestMapBackend_UnmarshalKey(t *testing.T) {
 		"database.port": 5432,
 	})
 
-	// UnmarshalKey is a no-op for MapBackend but should not error
 	type dbCfg struct {
 		Host string
 		Port int
@@ -263,7 +266,38 @@ func TestMapBackend_UnmarshalKey(t *testing.T) {
 	var db dbCfg
 	err := backend.UnmarshalKey("database", &db)
 	require.NoError(t, err)
-	// Note: MapBackend.UnmarshalKey is a no-op
+	assert.Equal(t, "dbhost", db.Host)
+	assert.Equal(t, 5432, db.Port)
+}
+
+func TestMapBackend_UnmarshalKeyMissing(t *testing.T) {
+	t.Parallel()
+	backend := config.NewMapBackend(nil)
+
+	var db struct {
+		Host string
+	}
+	err := backend.UnmarshalKey("database", &db)
+	require.ErrorIs(t, err, config.ErrKeyNotFound)
+}
+
+func TestMapBackend_UnmarshalKeyWithGazTag(t *testing.T) {
+	t.Parallel()
+	backend := config.NewMapBackend(map[string]any{
+		"server.host": "gazhost",
+		"server.port": 8081,
+	})
+
+	var cfg struct {
+		Host string `gaz:"host"`
+		Port int    `gaz:"port"`
+	}
+	err := backend.UnmarshalKeyWithGazTag("server", &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "gazhost", cfg.Host)
+	assert.Equal(t, 8081, cfg.Port)
+	assert.True(t, backend.HasKey("server"))
+	assert.False(t, backend.HasKey("missing"))
 }
 
 // =============================================================================

--- a/di/module.go
+++ b/di/module.go
@@ -3,16 +3,13 @@ package di
 // Module represents a reusable bundle of providers that register
 // services in a DI container.
 //
-// This interface is defined in the di package to allow subsystem packages
-// (like health, worker, cron) to return Module without importing the gaz
-// package, which would create an import cycle.
-//
-// Use with gaz.App.Use() which accepts di.Module via the gaz.Module type alias.
+// This interface is defined in the di package for adapters that should register
+// directly into a DI container. Use gaz.App.UseDI() to apply one to an App.
 //
 // Example:
 //
-//	module := worker.NewModule()
-//	app := gaz.New().Use(module)
+//	module := di.NewModuleFunc("custom", registerCustom)
+//	app := gaz.New().UseDI(module)
 type Module interface {
 	// Name returns the module's identifier for debugging and error messages.
 	Name() string

--- a/examples/microservice/README.md
+++ b/examples/microservice/README.md
@@ -73,7 +73,7 @@ Shutdown complete
 
 ## Key Patterns
 
-1. **Health Module:** `health.NewModule()` provides readiness/liveness probes
+1. **Health Module:** `health/module.New()` provides readiness/liveness probes
 2. **Event-Driven:** Workers communicate via typed events
 3. **Lifecycle Integration:** Workers implement `worker.Worker` interface
 4. **Dependency Injection:** EventBus is injected into workers

--- a/gaztest/README.md
+++ b/gaztest/README.md
@@ -10,7 +10,7 @@ app, err := gaztest.New(t).Build()
 app.RequireStart()
 defer app.RequireStop()
 
-// With modules (v3 pattern)
+// With modules (v3 pattern; accepts gaz.Module and di.Module)
 app, err := gaztest.New(t).
     WithModules(myModule).
     Build()
@@ -63,15 +63,18 @@ func TestUserService_Create(t *testing.T) {
 
 ### Integration Testing with Modules
 
-When testing module interactions, use WithModules:
+When testing module interactions, use `WithGazModules` for feature modules
+that return `gaz.Module`, and `WithModules` for lower-level `di.Module`
+adapters:
 
 ```go
 func TestHealthModule_Integration(t *testing.T) {
     cfg := health.TestConfig()
-    module := health.NewModule(health.WithConfig(cfg))
-    
+    module := healthmod.New()
+
     app, err := gaztest.New(t).
-        WithModules(module).
+        WithConfigMap(map[string]any{"health": cfg}).
+        WithGazModules(module).
         Build()
     require.NoError(t, err)
     

--- a/gaztest/README.md
+++ b/gaztest/README.md
@@ -10,9 +10,9 @@ app, err := gaztest.New(t).Build()
 app.RequireStart()
 defer app.RequireStop()
 
-// With modules (v3 pattern; accepts gaz.Module and di.Module)
+// With DI modules (use WithGazModules for gaz.Module)
 app, err := gaztest.New(t).
-    WithModules(myModule).
+    WithModules(diModule).
     Build()
 
 // Type-safe resolution that fails on error

--- a/gaztest/builder.go
+++ b/gaztest/builder.go
@@ -30,6 +30,10 @@ type replacement struct {
 	instance any
 }
 
+type testModule struct {
+	apply func(*gaz.App)
+}
+
 // Builder configures a test application.
 // Create with New(t), configure with fluent methods, and call Build() to get the App.
 type Builder struct {
@@ -37,7 +41,7 @@ type Builder struct {
 	timeout      time.Duration
 	replacements []replacement
 	baseApp      *gaz.App
-	modules      []di.Module
+	modules      []testModule
 	configMap    map[string]any
 	errs         []error
 }
@@ -71,8 +75,8 @@ func (b *Builder) WithApp(app *gaz.App) *Builder {
 	return b
 }
 
-// WithModules registers the given modules with the test app during build.
-// Modules are registered in order via app.Use().
+// WithModules registers the given DI modules with the test app during build.
+// Use WithGazModules for feature packages that return gaz.Module values.
 //
 // Note: WithModules cannot be used together with WithApp - they are mutually exclusive.
 // Build() will return an error if both are used.
@@ -80,11 +84,65 @@ func (b *Builder) WithApp(app *gaz.App) *Builder {
 // Example:
 //
 //	app, err := gaztest.New(t).
-//	    WithModules(worker.NewModule()).
+//	    WithModules(di.NewModuleFunc("worker", registerWorker)).
 //	    Build()
-func (b *Builder) WithModules(m ...di.Module) *Builder {
-	b.modules = append(b.modules, m...)
+func (b *Builder) WithModules(modules ...di.Module) *Builder {
+	for _, module := range modules {
+		adapted, err := adaptDIModule(module)
+		if err != nil {
+			b.errs = append(b.errs, err)
+			continue
+		}
+		b.modules = append(b.modules, adapted)
+	}
 	return b
+}
+
+// WithGazModules registers the given gaz modules with the test app during build.
+// This is for feature modules that are normally applied through app.Use().
+//
+// Note: WithGazModules cannot be used together with WithApp - they are mutually exclusive.
+// Build() will return an error if both are used.
+//
+// Example:
+//
+//	app, err := gaztest.New(t).
+//	    WithGazModules(workermod.New()).
+//	    Build()
+func (b *Builder) WithGazModules(modules ...gaz.Module) *Builder {
+	for _, module := range modules {
+		adapted, err := adaptGazModule(module)
+		if err != nil {
+			b.errs = append(b.errs, err)
+			continue
+		}
+		b.modules = append(b.modules, adapted)
+	}
+	return b
+}
+
+func adaptDIModule(module di.Module) (testModule, error) {
+	if module == nil {
+		return testModule{}, errors.New("gaztest: WithModules: module cannot be nil")
+	}
+
+	return testModule{
+		apply: func(app *gaz.App) {
+			app.UseDI(module)
+		},
+	}, nil
+}
+
+func adaptGazModule(module gaz.Module) (testModule, error) {
+	if module == nil {
+		return testModule{}, errors.New("gaztest: WithGazModules: module cannot be nil")
+	}
+
+	return testModule{
+		apply: func(app *gaz.App) {
+			app.Use(module)
+		},
+	}, nil
 }
 
 // WithConfigMap injects raw config values for testing.
@@ -162,7 +220,7 @@ func (b *Builder) Build() (*App, error) {
 
 		// Register modules if provided
 		for _, m := range b.modules {
-			gazApp.UseDI(m)
+			m.apply(gazApp)
 		}
 	}
 

--- a/gaztest/doc.go
+++ b/gaztest/doc.go
@@ -18,11 +18,11 @@
 //
 // # With Modules (v3 Pattern)
 //
-// Use WithModules for testing modules without a pre-built app:
+// Use WithGazModules for testing feature modules without a pre-built app:
 //
 //	func TestWithModules(t *testing.T) {
 //	    app, err := gaztest.New(t).
-//	        WithModules(worker.NewModule()).
+//	        WithGazModules(workermod.New()).
 //	        Build()
 //	    require.NoError(t, err)
 //

--- a/gaztest/gaztest_test.go
+++ b/gaztest/gaztest_test.go
@@ -560,6 +560,23 @@ func TestBuilder_WithModules(t *testing.T) {
 	require.Equal(t, "test-value-from-module", value)
 }
 
+func TestBuilder_WithModules_GazModule(t *testing.T) {
+	testModule := gaz.NewModule("gaz-module").
+		Provide(func(c *gaz.Container) error {
+			return gaz.For[string](c).Instance("test-value-from-gaz-module")
+		}).
+		Build()
+
+	app, err := gaztest.New(t).
+		WithGazModules(testModule).
+		Build()
+	require.NoError(t, err)
+
+	value, err := gaz.Resolve[string](app.Container())
+	require.NoError(t, err)
+	require.Equal(t, "test-value-from-gaz-module", value)
+}
+
 // =============================================================================
 // TestBuilder_WithModules_MultipleModules
 // =============================================================================

--- a/health_auto_registration.go
+++ b/health_auto_registration.go
@@ -38,10 +38,12 @@ func (a *App) autoRegisterHealth() error {
 	mod := NewModule(health.ModuleName).
 		Provide(health.Module).
 		Build()
+	if err := a.registerModuleIdentity(health.ModuleName); err != nil {
+		return err
+	}
 	if err := mod.Apply(a); err != nil {
 		return fmt.Errorf("auto-register health module: %w", err)
 	}
-	a.modules[health.ModuleName] = true
 
 	return nil
 }

--- a/internal/configuredmodule/config.go
+++ b/internal/configuredmodule/config.go
@@ -2,9 +2,11 @@
 package configuredmodule
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/config"
 )
 
 type namespacedValidatedConfig[T any] interface {
@@ -25,7 +27,9 @@ func ProvideValidated[T any, PT namespacedValidatedConfig[T]](
 	registrationName string,
 	validationContext string,
 ) func(*gaz.Container) error {
-	return provide(defaults, registrationName, validationContext, func(PT) {})
+	return provide(defaults, registrationName, validationContext, func(PT) error {
+		return nil
+	})
 }
 
 // ProvideDefaulted registers a config provider that starts from defaults,
@@ -36,8 +40,24 @@ func ProvideDefaulted[T any, PT defaultedConfig[T]](
 	registrationName string,
 	validationContext string,
 ) func(*gaz.Container) error {
-	return provide(defaults, registrationName, validationContext, func(cfg PT) {
+	return ProvideDefaultedWithHook[T, PT](defaults, registrationName, validationContext, nil)
+}
+
+// ProvideDefaultedWithHook registers a config provider like ProvideDefaulted,
+// then runs a hook before validation. This keeps uncommon module-specific
+// fallback policy behind the same configured module registration rule.
+func ProvideDefaultedWithHook[T any, PT defaultedConfig[T]](
+	defaults *T,
+	registrationName string,
+	validationContext string,
+	beforeValidate func(PT) error,
+) func(*gaz.Container) error {
+	return provide(defaults, registrationName, validationContext, func(cfg PT) error {
 		cfg.SetDefaults()
+		if beforeValidate == nil {
+			return nil
+		}
+		return beforeValidate(cfg)
 	})
 }
 
@@ -45,7 +65,7 @@ func provide[T any, PT namespacedValidatedConfig[T]](
 	defaults *T,
 	registrationName string,
 	validationContext string,
-	beforeValidate func(PT),
+	beforeValidate func(PT) error,
 ) func(*gaz.Container) error {
 	return func(c *gaz.Container) error {
 		if defaults == nil {
@@ -56,13 +76,14 @@ func provide[T any, PT namespacedValidatedConfig[T]](
 			cfg := *defaults
 			cfgPtr := PT(&cfg)
 
-			if pv, err := gaz.Resolve[*gaz.ProviderValues](c); err == nil {
-				if unmarshalErr := pv.UnmarshalKey(cfgPtr.Namespace(), &cfg); unmarshalErr != nil {
-					_ = unmarshalErr
-				}
+			if err := OverlayProviderValues(c, cfgPtr); err != nil {
+				return cfg, err
 			}
 
-			beforeValidate(cfgPtr)
+			if err := beforeValidate(cfgPtr); err != nil {
+				return cfg, fmt.Errorf("%s: %w", validationContext, err)
+			}
+
 			if err := cfgPtr.Validate(); err != nil {
 				return cfg, fmt.Errorf("%s: %w", validationContext, err)
 			}
@@ -73,4 +94,26 @@ func provide[T any, PT namespacedValidatedConfig[T]](
 		}
 		return nil
 	}
+}
+
+// OverlayProviderValues overlays a module-owned config from ProviderValues.
+// A missing ProviderValues service or missing namespace keeps defaults. Other
+// errors are malformed config and should fail at the config module seam.
+func OverlayProviderValues(c *gaz.Container, cfg interface{ Namespace() string }) error {
+	pv, err := gaz.Resolve[*gaz.ProviderValues](c)
+	if err != nil {
+		if errors.Is(err, gaz.ErrDINotFound) {
+			return nil
+		}
+		return fmt.Errorf("resolve ProviderValues: %w", err)
+	}
+
+	if unmarshalErr := pv.UnmarshalKey(cfg.Namespace(), cfg); unmarshalErr != nil {
+		if errors.Is(unmarshalErr, config.ErrKeyNotFound) {
+			return nil
+		}
+		return fmt.Errorf("load provider config %q: %w", cfg.Namespace(), unmarshalErr)
+	}
+
+	return nil
 }

--- a/internal/configuredmodule/config_test.go
+++ b/internal/configuredmodule/config_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/config"
 )
 
 const (
@@ -119,6 +120,44 @@ func TestProvideValidatedLoadsProviderValues(t *testing.T) {
 	cfg, err := gaz.Resolve[sampleValidatedConfig](app.Container())
 	require.NoError(t, err)
 	require.Equal(t, "https://example.test", cfg.Endpoint)
+}
+
+func TestProvideValidatedKeepsDefaultsWhenProviderNamespaceMissing(t *testing.T) {
+	app := gaz.New().WithConfig(nil, config.WithBackend(config.NewMapBackend(nil)))
+	defaults := sampleValidatedConfig{Endpoint: "https://default.example.test"}
+	app.Use(gaz.NewModule("validated").
+		Provide(ProvideValidated[sampleValidatedConfig, *sampleValidatedConfig](
+			&defaults,
+			"validated config",
+			"validated config validate",
+		)).
+		Build())
+
+	require.NoError(t, app.Build())
+
+	cfg, err := gaz.Resolve[sampleValidatedConfig](app.Container())
+	require.NoError(t, err)
+	require.Equal(t, "https://default.example.test", cfg.Endpoint)
+}
+
+func TestProvideValidatedRejectsMalformedProviderOverlay(t *testing.T) {
+	app := gaz.New().WithConfig(nil, config.WithBackend(config.NewMapBackend(map[string]any{
+		"validated.endpoint": map[string]any{"not": "a string"},
+	})))
+	defaults := sampleValidatedConfig{Endpoint: "https://default.example.test"}
+	app.Use(gaz.NewModule("validated").
+		Provide(ProvideValidated[sampleValidatedConfig, *sampleValidatedConfig](
+			&defaults,
+			"validated config",
+			"validated config validate",
+		)).
+		Build())
+
+	require.NoError(t, app.Build())
+
+	_, err := gaz.Resolve[sampleValidatedConfig](app.Container())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "load provider config \"validated\"")
 }
 
 func TestProviderUsesLatestDefaultValues(t *testing.T) {

--- a/module_builder.go
+++ b/module_builder.go
@@ -161,11 +161,9 @@ func (m *builtModule) Apply(app *App) error {
 	for _, child := range m.childModules {
 		childName := child.Name()
 
-		// Check for duplicate child module name
-		if app.modules[childName] {
-			return fmt.Errorf("%w: %s", ErrModuleDuplicate, childName)
+		if err := app.registerModuleIdentity(childName); err != nil {
+			return err
 		}
-		app.modules[childName] = true
 
 		if err := child.Apply(app); err != nil {
 			return fmt.Errorf("child module %s: %w", childName, err)

--- a/module_identity_policy.go
+++ b/module_identity_policy.go
@@ -1,0 +1,14 @@
+package gaz
+
+import "fmt"
+
+// registerModuleIdentity records a module identity for duplicate detection.
+// Module identity is the shared policy surface for Use, UseDI, Module, and
+// child module application.
+func (a *App) registerModuleIdentity(name string) error {
+	if a.modules[name] {
+		return fmt.Errorf("%w: %s", ErrModuleDuplicate, name)
+	}
+	a.modules[name] = true
+	return nil
+}

--- a/server/module_test.go
+++ b/server/module_test.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/config"
 	"github.com/petabytecl/gaz/di"
 	hello "github.com/petabytecl/gaz/examples/vanguard/proto"
 	servergrpc "github.com/petabytecl/gaz/server/grpc"
@@ -87,6 +88,17 @@ func TestNewModule_ForcesGRPCServiceRegistrationOnly(t *testing.T) {
 	require.Equal(t, 1024, cfg.MaxRecvMsgSize)
 	require.Equal(t, 2048, cfg.MaxSendMsgSize)
 	require.True(t, cfg.SkipListener)
+}
+
+func TestNewModule_RejectsMalformedGRPCOverlay(t *testing.T) {
+	app := gaz.New().WithConfig(nil, config.WithBackend(config.NewMapBackend(map[string]any{
+		"grpc": "not-a-config-map",
+	})))
+	app.Use(NewModule())
+
+	err := app.Build()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "load provider config \"grpc\"")
 }
 
 func TestNewModule_BridgesGRPCServicesThroughVanguard(t *testing.T) {

--- a/server/otel/doc.go
+++ b/server/otel/doc.go
@@ -13,7 +13,8 @@
 // # Configuration
 //
 // The package can be configured via:
-//   - Module options (WithEndpoint, WithServiceName, WithSampleRatio)
+//   - Module flags (--otel-endpoint, --otel-service-name, --otel-sample-ratio)
+//   - App config files and ProviderValues under the "otel" namespace
 //   - Environment variables (OTEL_EXPORTER_OTLP_ENDPOINT as fallback)
 //
 // # Usage
@@ -21,10 +22,7 @@
 // Use NewModule to register the TracerProvider with the DI container:
 //
 //	app := gaz.New()
-//	app.Use(otel.NewModule(
-//	    otel.WithEndpoint("localhost:4317"),
-//	    otel.WithServiceName("my-service"),
-//	))
+//	app.Use(otel.NewModule())
 //
 // The TracerProvider is automatically shut down when the application stops.
 //

--- a/server/otel/module.go
+++ b/server/otel/module.go
@@ -9,27 +9,48 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/internal/configuredmodule"
 )
 
-// tracerProviderStopper wraps TracerProvider to implement di.Stopper.
-type tracerProviderStopper struct {
+// tracerRuntime owns the active or disabled OTEL runtime state.
+type tracerRuntime struct {
 	tp *sdktrace.TracerProvider
 }
 
-// OnStop shuts down the TracerProvider.
-func (t *tracerProviderStopper) OnStop(ctx context.Context) error {
-	return ShutdownTracer(ctx, t.tp)
+func newTracerRuntime(ctx context.Context, cfg Config, logger *slog.Logger) (*tracerRuntime, error) {
+	tp, err := InitTracer(ctx, cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+	return &tracerRuntime{tp: tp}, nil
+}
+
+// TracerProvider returns the active TracerProvider, or nil when tracing is disabled.
+func (r *tracerRuntime) TracerProvider() *sdktrace.TracerProvider {
+	if r == nil {
+		return nil
+	}
+	return r.tp
+}
+
+// OnStop shuts down the active TracerProvider. Disabled tracing is a no-op.
+func (r *tracerRuntime) OnStop(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	return ShutdownTracer(ctx, r.tp)
 }
 
 // NewModule creates an OTEL module.
 // Returns a gaz.Module that registers TracerProvider components.
 //
-// If no endpoint is configured (via flags or OTEL_EXPORTER_OTLP_ENDPOINT env var),
-// tracing is disabled and a nil TracerProvider is registered.
+// If no endpoint is configured (via flags or OTEL_EXPORTER_OTLP_ENDPOINT env
+// var), tracing is disabled and resolving *sdktrace.TracerProvider returns nil.
 //
 // Components registered:
 //   - otel.Config
 //   - *sdktrace.TracerProvider (may be nil if disabled)
+//   - internal OTEL runtime participant for graceful shutdown
 //
 // Example:
 //
@@ -40,74 +61,61 @@ func NewModule() gaz.Module {
 
 	return gaz.NewModule(ModuleName).
 		Flags(defaultCfg.Flags).
-		Provide(func(c *gaz.Container) error {
-			// Register Config provider
-			return gaz.For[Config](c).Provider(func(c *gaz.Container) (Config, error) {
-				var cfg Config
-				cfg.SetDefaults()
-
-				// Resolve ProviderValues to load config
-				if pv, err := gaz.Resolve[*gaz.ProviderValues](c); err == nil {
-					if unmarshalErr := pv.UnmarshalKey(defaultCfg.Namespace(), &cfg); unmarshalErr != nil {
-						// ignore error
-						_ = unmarshalErr
-					}
-				}
-
-				// Check environment variable fallback
-				if cfg.Endpoint == "" {
-					cfg.Endpoint = os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-				}
-
-				if err := cfg.Validate(); err != nil {
-					return Config{}, fmt.Errorf("otel config validate: %w", err)
-				}
-
-				return cfg, nil
-			})
-		}).
+		Provide(provideConfig(&defaultCfg)).
+		Provide(registerTracerRuntime).
 		Provide(registerTracerProvider).
-		Provide(registerTracerStopper).
 		Build()
 }
 
-// registerTracerProvider registers the TracerProvider with the container.
-func registerTracerProvider(c *gaz.Container) error {
-	if err := gaz.For[*sdktrace.TracerProvider](c).
+func provideConfig(defaultCfg *Config) func(*gaz.Container) error {
+	return configuredmodule.ProvideDefaultedWithHook[Config, *Config](
+		defaultCfg,
+		"otel config",
+		"otel config validate",
+		func(cfg *Config) error {
+			if cfg.Endpoint == "" {
+				cfg.Endpoint = os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+			}
+			return nil
+		},
+	)
+}
+
+// registerTracerRuntime registers the module that owns active and disabled OTEL state.
+func registerTracerRuntime(c *gaz.Container) error {
+	if err := gaz.For[*tracerRuntime](c).
 		Eager().
-		Provider(func(c *gaz.Container) (*sdktrace.TracerProvider, error) {
+		Provider(func(c *gaz.Container) (*tracerRuntime, error) {
 			cfg, err := gaz.Resolve[Config](c)
 			if err != nil {
 				return nil, fmt.Errorf("resolve otel config: %w", err)
 			}
 
-			logger := slog.Default()
-			if resolved, resolveErr := gaz.Resolve[*slog.Logger](c); resolveErr == nil {
-				logger = resolved
-			}
+			return newTracerRuntime(context.Background(), cfg, resolveLogger(c))
+		}); err != nil {
+		return fmt.Errorf("register tracer runtime: %w", err)
+	}
+	return nil
+}
 
-			return InitTracer(context.Background(), cfg, logger)
+// registerTracerProvider registers the TracerProvider with the container.
+func registerTracerProvider(c *gaz.Container) error {
+	if err := gaz.For[*sdktrace.TracerProvider](c).
+		Provider(func(c *gaz.Container) (*sdktrace.TracerProvider, error) {
+			runtime, err := gaz.Resolve[*tracerRuntime](c)
+			if err != nil {
+				return nil, fmt.Errorf("resolve tracer runtime: %w", err)
+			}
+			return runtime.TracerProvider(), nil
 		}); err != nil {
 		return fmt.Errorf("register tracer provider: %w", err)
 	}
 	return nil
 }
 
-// registerTracerStopper registers the TracerProvider stopper.
-// This ensures TracerProvider is shut down when the app stops.
-func registerTracerStopper(c *gaz.Container) error {
-	if err := gaz.For[*tracerProviderStopper](c).
-		Provider(func(c *gaz.Container) (*tracerProviderStopper, error) {
-			tp, err := gaz.Resolve[*sdktrace.TracerProvider](c)
-			if err != nil {
-				return nil, fmt.Errorf("resolve tracer provider: %w", err)
-			}
-			if tp == nil {
-				return nil, nil //nolint:nilnil // No stopper needed if tracing disabled.
-			}
-			return &tracerProviderStopper{tp: tp}, nil
-		}); err != nil {
-		return fmt.Errorf("register tracer stopper: %w", err)
+func resolveLogger(c *gaz.Container) *slog.Logger {
+	if resolved, err := gaz.Resolve[*slog.Logger](c); err == nil {
+		return resolved
 	}
-	return nil
+	return slog.Default()
 }

--- a/server/otel/module_test.go
+++ b/server/otel/module_test.go
@@ -10,6 +10,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/config"
 	"github.com/petabytecl/gaz/di"
 )
 
@@ -59,6 +60,17 @@ func TestNewModule_EnvFallback(t *testing.T) {
 	assert.Equal(t, "localhost:4317", cfg.Endpoint, "should use env var as fallback")
 }
 
+func TestNewModule_MalformedProviderOverlayFailsBuild(t *testing.T) {
+	app := gaz.New().WithConfig(nil, config.WithBackend(config.NewMapBackend(map[string]any{
+		"otel": "not-a-config-map",
+	})))
+	app.Use(NewModule())
+
+	err := app.Build()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "load provider config \"otel\"")
+}
+
 func TestNewModule_TracerStopper(t *testing.T) {
 	app := gaz.New()
 
@@ -72,17 +84,26 @@ func TestNewModule_TracerStopper(t *testing.T) {
 
 	c := app.Container()
 
-	// Stopper should be resolvable (may be nil if tracing disabled)
-	stopper, err := di.Resolve[*tracerProviderStopper](c)
+	// Runtime should be resolvable and non-nil even when tracing is disabled.
+	runtime, err := di.Resolve[*tracerRuntime](c)
 	require.NoError(t, err)
-	assert.Nil(t, stopper, "stopper should be nil when tracing disabled")
+	require.NotNil(t, runtime)
+	assert.Nil(t, runtime.TracerProvider(), "tracer provider should be nil when tracing disabled")
 }
 
-func TestTracerProviderStopper_OnStop(t *testing.T) {
-	// Test the stopper with nil provider
-	stopper := &tracerProviderStopper{tp: nil}
+func TestNewModule_DisabledRuntimeStopsCleanly(t *testing.T) {
+	app := gaz.New()
+	app.Use(NewModule())
 
-	err := stopper.OnStop(context.Background())
+	require.NoError(t, app.Build())
+	require.NoError(t, app.Start(context.Background()))
+	require.NoError(t, app.Stop(context.Background()))
+}
+
+func TestTracerRuntime_OnStopDisabled(t *testing.T) {
+	runtime := &tracerRuntime{tp: nil}
+
+	err := runtime.OnStop(context.Background())
 	assert.NoError(t, err, "stopping nil provider should succeed")
 }
 
@@ -114,12 +135,12 @@ func TestNewModule_ModuleName(t *testing.T) {
 	assert.Equal(t, ModuleName, module.Name())
 }
 
-// Verify that the stopper implements proper cleanup.
-func TestTracerProviderStopper_Interface(t *testing.T) {
-	// Verify tracerProviderStopper has OnStop method (di.Stopper)
+// Verify that the runtime implements proper cleanup.
+func TestTracerRuntime_Interface(t *testing.T) {
+	// Verify tracerRuntime has OnStop method (di.Stopper)
 	var _ interface {
 		OnStop(context.Context) error
-	} = &tracerProviderStopper{}
+	} = &tracerRuntime{}
 }
 
 func TestNewModule_TracerProvider_WhenEnabled(t *testing.T) {
@@ -143,39 +164,38 @@ func TestNewModule_TracerProvider_WhenEnabled(t *testing.T) {
 	// May be non-nil even if endpoint unreachable
 	if tp != nil {
 		// Clean up
-		stopper, _ := di.Resolve[*tracerProviderStopper](c)
-		if stopper != nil {
-			_ = stopper.OnStop(context.Background())
+		runtime, _ := di.Resolve[*tracerRuntime](c)
+		if runtime != nil {
+			_ = runtime.OnStop(context.Background())
 		}
 	}
 }
 
-func TestRegisterTracerProvider_MissingConfig(t *testing.T) {
+func TestRegisterTracerRuntime_MissingConfig(t *testing.T) {
 	c := di.New()
 
 	// Register logger but NOT Config
 	err := di.For[*slog.Logger](c).Instance(slog.Default())
 	require.NoError(t, err)
 
-	// Register tracer provider - registration should succeed
-	err = registerTracerProvider(c)
+	// Register tracer runtime - registration should succeed
+	err = registerTracerRuntime(c)
 	require.NoError(t, err)
 
 	// Resolving should fail due to missing Config
-	_, err = di.Resolve[*sdktrace.TracerProvider](c)
+	_, err = di.Resolve[*tracerRuntime](c)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "config")
 }
 
-func TestRegisterTracerStopper_MissingProvider(t *testing.T) {
+func TestRegisterTracerProvider_MissingRuntime(t *testing.T) {
 	c := di.New()
 
-	// Don't register TracerProvider
-	// Register stopper - registration should succeed
-	err := registerTracerStopper(c)
+	// Don't register tracerRuntime.
+	err := registerTracerProvider(c)
 	require.NoError(t, err)
 
-	// Resolving should fail due to missing TracerProvider
-	_, err = di.Resolve[*tracerProviderStopper](c)
+	// Resolving should fail due to missing runtime.
+	_, err = di.Resolve[*sdktrace.TracerProvider](c)
 	require.Error(t, err)
 }

--- a/server/unified_server_bridge.go
+++ b/server/unified_server_bridge.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/petabytecl/gaz"
+	"github.com/petabytecl/gaz/internal/configuredmodule"
 	"github.com/petabytecl/gaz/server/grpc"
 	"github.com/petabytecl/gaz/server/vanguard"
 )
@@ -42,7 +43,9 @@ func forceGRPCServiceRegistrationOnly(c *gaz.Container) error {
 
 func grpcBridgeConfig(c *gaz.Container) (grpc.Config, error) {
 	cfg := grpc.DefaultConfig()
-	overlayGRPCProviderValues(c, &cfg)
+	if err := overlayGRPCProviderValues(c, &cfg); err != nil {
+		return grpc.Config{}, err
+	}
 
 	cfg.SkipListener = true
 
@@ -52,12 +55,9 @@ func grpcBridgeConfig(c *gaz.Container) (grpc.Config, error) {
 	return cfg, nil
 }
 
-func overlayGRPCProviderValues(c *gaz.Container, cfg *grpc.Config) {
-	pv, err := gaz.Resolve[*gaz.ProviderValues](c)
-	if err != nil {
-		return
+func overlayGRPCProviderValues(c *gaz.Container, cfg *grpc.Config) error {
+	if err := configuredmodule.OverlayProviderValues(c, cfg); err != nil {
+		return fmt.Errorf("overlay grpc provider values: %w", err)
 	}
-	if unmarshalErr := pv.UnmarshalKey(cfg.Namespace(), cfg); unmarshalErr != nil {
-		return
-	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- fail malformed ProviderValues overlays at the configured-module seam instead of silently keeping defaults
- make OTEL disabled state explicit through a runtime participant that owns shutdown behavior
- centralize module identity duplicate checks across app/module application paths
- move config loading into the named build phase sequence
- keep `gaztest.WithModules` compatible for `di.Module` while adding `WithGazModules` for feature modules

## Why

The architecture review found several places where policy was spread across call sites or failure paths were hidden. This change keeps the existing public behavior where it matters, but makes malformed config visible, gives disabled OTEL a concrete lifecycle object, and keeps module identity/build ordering rules local and testable.

## Validation

- `make check`
- tracked-file `gofmt`
- `go run golang.org/x/tools/cmd/goimports@latest -l $(git ls-files "*.go")`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod GOLANGCI_LINT_CACHE=/tmp/golangci-lint make lint`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./... -count=1`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make test`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make cover` (`90.8%`)

Note: `make fmt-check` is distorted in this environment by the local `goimports` mise shim, so the upstream `goimports` command above was used as the import-format gate.
